### PR TITLE
feat(audit): add tamper-evident integrity chain to the audit event store

### DIFF
--- a/.memory-bank/AUDIT_EVENT_INTEGRITY_PROJECT_PLAN.md
+++ b/.memory-bank/AUDIT_EVENT_INTEGRITY_PROJECT_PLAN.md
@@ -1,0 +1,924 @@
+# Audit Event Integrity Project Plan
+
+Date: 2026-08-11
+Status: Open tracking plan
+Audience: coder-manager and coder-* sub-agents (sub-agent dispatch mode)
+Authority: `ADR_SEMANTICA_EVIDENCE_AND_GOVERNANCE_ADOPTION.md`, section 3.
+This tracking file governs execution; the ADR governs the decision.
+
+## Manager Tracking
+
+```yaml
+manager_loop:
+  status: closed
+  active_next_task: null
+  selected_task: null
+  no_selected_task_reason: all tasks DONE
+  last_decision:
+    outcome: completed
+    label: TASK-5
+    reason: "A second review found TASK-4 incomplete. Stripping every integrity envelope and declaring schemaVersion 1 produced LEGACY_UNVERIFIED, and one ordinary append then re-signed the tampered history as dispatchable VALID_WITH_LEGACY_PREFIX. TASK-5 removes in-place migration entirely: legacy stores are read-only, dispatch requires a fully verified chain, and acknowledged reset accepts LEGACY_UNVERIFIED so operators have a safe exit."
+    planning_work_considered: true
+    reopen_gate: "Reopen if any write path can convert unverified history into a dispatchable status, or if an operator can reach a state that acknowledged reset refuses."
+  closeout_state: complete
+  dispatch_mode: sub-agent
+  selection_policy: active_next_task-first
+  auto_continue: until-stop-condition
+  dispatch_preflight:
+    tool_surface: unchecked
+    child_capability_probes: {}
+    required_roles:
+      coder-architector:
+        agent_type_candidates:
+        - coder-architector
+        local_fallback_allowed: false
+        required_for:
+        - dor-dod-adr-gate
+        - readiness
+        - closeout
+      coder-worker:
+        agent_type_candidates:
+        - coder-worker
+        local_fallback_allowed: false
+        required_for:
+        - implementation
+      coder-worker-test-challenger:
+        agent_type_candidates:
+        - coder-worker-test-challenger
+        local_fallback_allowed: false
+        required_for:
+        - verification
+        - challenge
+    fork_context: false
+    unavailable_outcome: 'blocked: model/capacity'
+  ontoindex:
+    required: true
+    status: review
+    unavailable_action: direct-source-fallback
+    tools_used:
+    - gn_ensure_fresh(repo=ontoindex)
+    - inspect(action=context, target=LocalAuditEventStore)
+    - inspect(action=context, target=gnAuditExport)
+    - inspect(action=context, target=gnAuditTombstoneCreate)
+    - impact(action=symbol, target_uid=Method:ontoindex/src/core/audit-lifecycle/audit-event-store.ts:LocalAuditEventStore.appendEvent#2, direction=upstream, includeTests=true, maxDepth=3)
+    - search(action=semantic, query="audit CLI command registration subcommands audit export replay lint")
+    - ctx_compose audit CLI registration and source-owner verification
+    limitations:
+    - Graph authority is review because the untracked ADR and plan files change the source manifest; current source reads override graph metadata for exact line-level claims.
+    - Embeddings are absent, so semantic retrieval is degraded; symbol and call-edge evidence used here remains available.
+    - 'appendEvent impact is HIGH: 25 upstream nodes, 15 direct callers, 2 affected processes, and 3 affected modules. Every worker must rerun impact immediately before edits.'
+    source_fallback:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/src/core/audit-lifecycle/audit-session.ts
+    - ontoindex/src/core/audit-lifecycle/audit-projection.ts
+    - ontoindex/src/mcp/super/audit-advanced.ts
+    - ontoindex/src/mcp/super/audit-session-tools.ts
+    - ontoindex/src/cli/audit.ts
+    - ontoindex/src/cli/index.ts
+    - ontoindex/test/unit/audit-event-store.test.ts
+    - ontoindex/test/unit/audit-dispatch.test.ts
+    - ontoindex/test/integration/audit-cli.test.ts
+    fallback_evidence:
+    - AuditEvent is the domain event union consumed by projections and 15 direct append callers; storage integrity fields must not become required AuditEventBase fields.
+    - saveAuditEventStoreState normalizes the full state before each atomic rewrite; checksum input must be the persisted normalized event representation and normalization must be idempotent.
+    - The existing update lock and atomic temp-file rename already serialize appends; no second lock or storage service is needed.
+    - A v1 store cannot prove its pre-migration history. Migration may protect those bytes from the migration point forward but must report VALID_WITH_LEGACY_PREFIX, never VALID.
+    - Re-checksumming a broken store would launder untrusted history. Recovery must archive the broken store and start a fresh empty chain that requires re-ingest.
+  reopen_gate: null
+tasks:
+  TASK-1:
+    title: Add v2 persisted integrity envelopes and compatibility migration
+    status: DONE
+    classification: implementation-ready
+    dor_status: pass
+    dod_status: pass
+    depends_on: []
+    owner: coder-worker
+    reviewer: coder-worker-test-challenger
+    type: code
+    validation_tier: unit-fast
+    owner_files:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/test/unit/audit-event-store.test.ts
+    allowed_write_set:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/test/unit/audit-event-store.test.ts
+    target_symbols:
+    - LocalAuditEventStore.load
+    - LocalAuditEventStore.appendEvent
+    - loadAuditEventStoreState
+    - saveAuditEventStoreState
+    - normalizeAuditEventStoreState
+    - normalizeAuditEvent
+    - withAuditStoreUpdateLock
+    - AUDIT_EVENT_STORE_SCHEMA_VERSION
+    - AuditEventStoreState
+    do_not_touch:
+    - ontoindex/src/core/audit-lifecycle/audit-session.ts
+    - ontoindex/src/core/audit-lifecycle/audit-projection.ts
+    - ontoindex/src/core/audit-lifecycle/index.ts
+    - ontoindex/src/mcp/**
+    - ontoindex/src/cli/**
+    non_goals:
+    - Adding sequence/checksum fields to AuditEventBase or changing appendEvent callers.
+    - Adding signatures, remote witnesses, an append-only filesystem, or a storage dependency.
+    - Detecting rollback or deletion of a valid tail.
+    - Re-checksumming a BROKEN store.
+    - Changing projection semantics or output.
+    source_evidence:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts:23-154
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts:199-267
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts:270-360
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts:482-583
+    - ontoindex/src/core/audit-lifecycle/audit-session.ts:202-219
+    - ontoindex/src/core/audit-lifecycle/audit-session.ts:270-274
+    - ontoindex/test/unit/audit-event-store.test.ts:55-307
+    - 'OntoIndex impact: appendEvent HIGH, 25 upstream nodes / 15 direct callers / 2 processes / 3 modules.'
+    readiness_gaps: []
+    gap_resolution_task: null
+    gap_disposition: not-applicable
+    paperwork_kind: persistence-schema-v2
+    test_surface_gap: null
+    adr_gate:
+      required: true
+      reason: This changes persisted audit-event storage and trust semantics. The decision is authorized by ADR_SEMANTICA_EVIDENCE_AND_GOVERNANCE_ADOPTION.md section 3.
+      adr_path: ADR_SEMANTICA_EVIDENCE_AND_GOVERNANCE_ADOPTION.md
+      status: satisfied
+      decision_owner: coder-architector
+      allowed_write_set: []
+      unblocks:
+      - TASK-2
+      - TASK-3
+      promotion_rule: Do not dispatch until the worker accepts the v2 envelope, legacy trust-boundary, and no-rechain recovery constraints.
+      missing_adr_outcome: stop
+    dispatch:
+      role: coder-worker
+      assigned_agent: null
+      model_requested: null
+      model_effective: null
+      preflight_result: not-run
+      local_fallback_allowed: false
+      local_fallback_scope: null
+      attempts: 0
+      max_attempts: 3
+      required_capabilities:
+      - repository-read
+      - repository-write
+      - shell-execute
+      - ontoindex
+      dispatch_kind: implementation
+      wait_state: null
+      blocker_fingerprint: null
+      last_progress_revision: null
+      dispatch_id: null
+      scope_sha256: null
+      lease_state: null
+      dispatched_at: null
+      agent_type_requested: null
+      route_attempts: null
+      terminal_classification: null
+      result_receipt_id: null
+      result_verdict: null
+      result_blocker: null
+    validation:
+      required_commands:
+      - cd ontoindex && npx vitest run test/unit/audit-event-store.test.ts
+      - cd ontoindex && npx vitest run test/unit/audit-dispatch.test.ts test/unit/audit-session-lock.test.ts test/unit/audit-verify.test.ts test/integration/audit-lifecycle-mcp.test.ts test/integration/audit-cli.test.ts
+      - cd ontoindex && npx tsc --noEmit
+      - git diff --check -- ontoindex/src/core/audit-lifecycle/audit-event-store.ts ontoindex/test/unit/audit-event-store.test.ts
+      executed:
+      - cd ontoindex && npx vitest run test/unit/audit-event-store.test.ts
+      - cd ontoindex && npx vitest run test/unit/audit-dispatch.test.ts
+      - cd ontoindex && npx vitest run test/unit/audit-session-lock.test.ts
+      - cd ontoindex && npx vitest run test/unit/audit-verify.test.ts
+      - cd ontoindex && npx vitest run test/integration/audit-lifecycle-mcp.test.ts
+      - cd ontoindex && npx vitest run test/integration/audit-cli.test.ts
+      - cd ontoindex && npx tsc --noEmit
+      - git diff --check -- ontoindex/src/core/audit-lifecycle/audit-event-store.ts ontoindex/test/unit/audit-event-store.test.ts
+      diff_scope:
+      - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+      - ontoindex/test/unit/audit-event-store.test.ts
+      unrelated_failures: []
+    required_validation:
+    - cd ontoindex && npx vitest run test/unit/audit-event-store.test.ts
+    - cd ontoindex && npx vitest run test/unit/audit-dispatch.test.ts test/unit/audit-session-lock.test.ts test/unit/audit-verify.test.ts test/integration/audit-lifecycle-mcp.test.ts test/integration/audit-cli.test.ts
+    - cd ontoindex && npx tsc --noEmit
+    - git diff --check -- ontoindex/src/core/audit-lifecycle/audit-event-store.ts ontoindex/test/unit/audit-event-store.test.ts
+    expected_evidence:
+    - Persisted schema v2 wraps normalized AuditEvent payloads in storage-only integrity entries; AuditEvent and appendEvent input shapes remain source-compatible.
+    - Canonical JSON recursively sorts object keys, preserves array order, rejects unsupported values, excludes checksum, and includes integrity contract version, legacyPrefixLength, sequence, and previous checksum in the hash input.
+    - The genesis integrity entry uses sequence 0 and a named exported constant genesis previousChecksum literal; a unit test asserts both the sequence origin and the exact genesis literal.
+    - Store-level metadata participation is explicit: legacyPrefixLength participates in every per-entry checksum so the legacy trust boundary cannot be upgraded by metadata mutation; schemaVersion and migratedAt remain excluded.
+    - All nine event types pass normalize(normalize(event)) deep-equality fixtures, including non-UTC timestamps, duplicate/unsorted string arrays, and unknown fields.
+    - A three-event append produces deterministic sequence and linkage, and a second save/load cycle leaves checksums unchanged.
+    - Mutation, insertion, and reordering report BROKEN at the first affected sequence; save refuses BROKEN state rather than recomputing checksums.
+    - load() returns an additive integrity result for a chain-broken v2 store instead of throwing, while malformed JSON and duplicate-id stores keep throwing as today; a separate non-throwing inspection primitive reads raw bytes so recovery can archive a malformed store without load().
+    - saveAuditEventStoreState verifies the existing on-disk chain before writing and refuses when that chain is BROKEN; a test proves an external full-state save cannot convert BROKEN into VALID.
+    - A v1 store remains readable as LEGACY_UNVERIFIED. Its first locked append migrates normalized events to v2, records legacyPrefixLength and migratedAt, and reports VALID_WITH_LEGACY_PREFIX.
+    - Concurrent append coverage proves unique monotonic sequence values under the existing update lock.
+    - Deleting a valid tail still reports valid for the retained chain, documenting the explicit rollback limitation.
+    - A core recovery primitive uses the existing update lock, refuses healthy stores, archives a BROKEN or malformed store, records archive digest/path, creates a fresh empty v2 store, rebuilds an empty projection, and never re-checksums archived events.
+    rollback:
+    - Revert the two TASK-1 files; schema-v1 stores remain the only supported format.
+    - Do not run a downgrade over stores already written as v2; preserve them for forward recovery.
+    stop_conditions:
+    - Any AuditEventBase or appendEvent caller must change to carry storage integrity fields.
+    - Normalization is not idempotent and cannot be corrected inside audit-event-store.ts alone.
+    - Migration requires treating pre-migration v1 events as fully trusted.
+    - Recovery requires re-checksumming or mutating the archived broken history.
+    - Write scope must expand beyond the two listed files.
+    - Refusing a BROKEN on-disk chain in saveAuditEventStoreState requires changing callers outside the allowed write set.
+    closeout_evidence: []
+    evidence:
+    - "coder-architector 2026-08-11 NEEDS_REWORK integrated: F1 genesis/sequence/store-metadata checksum participation made explicit; F2 audit regression suite added to required_validation; F3 load() BROKEN-vs-throw contract made explicit; F4 on-disk save refusal against BROKEN chain made explicit; F5 dispatch block reset to coder-worker with cleared abandoned lease."
+    - "coder-architector 2026-08-11 re-gate PASS: F1-F5 closed; DoR/DoD pass; ADR section 3 satisfied; recommended next role coder-worker on the two TASK-1 owner files."
+    - "coder-worker PASS: storage-only v2 envelopes, genesis sequence 0, migration, recovery, concurrent append coverage."
+    - "coder-worker-test-challenger NEEDS_REWORK then PASS after fail-open fix: schema-v2 stores with stripped integrity envelopes are BROKEN and cannot be re-signed on save; regression test added."
+    - "Parent validation after fix: audit-event-store 13/13, dispatch 14/14, session-lock 5/5, verify 5/5, lifecycle-mcp 7/7, audit-cli 5/5, tsc clean, git diff --check clean, gn_verify_diff PASS for expected write set."
+    known_blockers: []
+    closeout:
+      role_results:
+        coder-architector: PASS
+        coder-worker: PASS
+        coder-worker-test-challenger: PASS
+        coder-auditor: null
+      changed_files:
+      - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+      - ontoindex/test/unit/audit-event-store.test.ts
+      validation_summary:
+      - "vitest audit-event-store 13 passed"
+      - "vitest regression 36 passed across 5 files"
+      - "tsc --noEmit clean"
+      - "git diff --check clean"
+      - "challenger PASS after stripped-envelope fail-open fix"
+      evidence_refs:
+      - "verifyIntegrity always runs for schema-v2; missing envelope => BROKEN missing-integrity-envelope"
+      - "saveAuditEventStoreState refuses BROKEN on-disk chain"
+      - "recoverAuditEventStore archives exact bytes and starts fresh empty chain"
+      final_outcome_label: done
+      remaining_risk: "Valid-tail deletion remains undetectable without an independent trust anchor, as designed."
+    next_on_done:
+    - TASK-2
+    - TASK-3
+    - TASK-4
+  TASK-2:
+    title: Enforce dispatch integrity and expose diagnostic status on read-only audit reports
+    status: DONE
+    classification: implementation-ready
+    dor_status: pass
+    dod_status: pass
+    depends_on:
+    - TASK-1
+    owner: coder-worker
+    reviewer: coder-worker-test-challenger
+    type: code
+    validation_tier: integration
+    owner_files:
+    - ontoindex/src/mcp/super/audit-advanced.ts
+    - ontoindex/src/mcp/super/audit-session-tools.ts
+    - ontoindex/test/unit/audit-dispatch.test.ts
+    - ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+    allowed_write_set:
+    - ontoindex/src/mcp/super/audit-advanced.ts
+    - ontoindex/src/mcp/super/audit-session-tools.ts
+    - ontoindex/test/unit/audit-dispatch.test.ts
+    - ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+    target_symbols:
+    - gnDispatchPrompt
+    - gnAuditSessionDispatch
+    - gnAuditDiff
+    - gnAuditReplay
+    - gnAuditExport
+    - loadManagerState
+    do_not_touch:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/src/core/audit-lifecycle/audit-projection.ts
+    - ontoindex/src/cli/**
+    - audit finding/status transition semantics
+    non_goals:
+    - Blocking read-only diff, replay, or export solely because the chain is BROKEN.
+    - Treating LEGACY_UNVERIFIED or VALID_WITH_LEGACY_PREFIX as fully trusted.
+    - Adding an MCP repair/reset operation.
+    - Changing dispatch finding eligibility rules unrelated to integrity.
+    - Changing gnAuditTombstoneCreate behavior on a BROKEN store; corruption refusal there comes from the TASK-1 save path and the ADR-required corrective path is TASK-3 archive-reset plus re-ingest.
+    source_evidence:
+    - ontoindex/src/mcp/super/audit-advanced.ts:89-159
+    - ontoindex/src/mcp/super/audit-session-tools.ts:200-317
+    - ontoindex/src/mcp/super/audit-session-tools.ts:474-536
+    - ontoindex/src/mcp/super/audit-session-tools.ts:706-710
+    - ontoindex/test/unit/audit-dispatch.test.ts
+    - ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+    - OntoIndex reports gnDispatchPrompt and gnAuditSessionVerify among appendEvent's affected processes/callers.
+    readiness_gaps: []
+    gap_resolution_task: null
+    gap_disposition: not-applicable
+    paperwork_kind: null
+    test_surface_gap: Current dispatch and read-only report tests do not model audit-store integrity states.
+    adr_gate:
+      required: true
+      reason: Dispatch fail-closed and read/export degraded-integrity behavior are explicit ADR requirements. This task consumes the TASK-1 store contract without changing persistence.
+      adr_path: ADR_SEMANTICA_EVIDENCE_AND_GOVERNANCE_ADOPTION.md
+      status: satisfied
+      decision_owner: coder-architector
+      allowed_write_set: []
+      unblocks: []
+      promotion_rule: TASK-1 must be DONE and expose a tested additive integrity result on LocalAuditEventStore.load().
+      missing_adr_outcome: stop
+    dispatch:
+      role: coder-worker
+      assigned_agent: null
+      model_requested: null
+      model_effective: null
+      preflight_result: not-run
+      local_fallback_allowed: false
+      local_fallback_scope: null
+      attempts: 0
+      max_attempts: 3
+      required_capabilities:
+      - repository-read
+      - repository-write
+      - shell-execute
+      - ontoindex
+      dispatch_kind: implementation
+      wait_state: null
+      blocker_fingerprint: null
+      last_progress_revision: null
+    validation:
+      required_commands:
+      - cd ontoindex && npx vitest run test/unit/audit-dispatch.test.ts test/integration/audit-lifecycle-mcp.test.ts
+      - cd ontoindex && npx tsc --noEmit
+      - git diff --check -- ontoindex/src/mcp/super/audit-advanced.ts ontoindex/src/mcp/super/audit-session-tools.ts ontoindex/test/unit/audit-dispatch.test.ts ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+      executed:
+      - cd ontoindex && npx vitest run test/unit/audit-dispatch.test.ts
+      - cd ontoindex && npx vitest run test/integration/audit-lifecycle-mcp.test.ts
+      - cd ontoindex && npx tsc --noEmit
+      - git diff --check -- ontoindex/src/mcp/super/audit-advanced.ts ontoindex/src/mcp/super/audit-session-tools.ts ontoindex/test/unit/audit-dispatch.test.ts ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+      diff_scope:
+      - ontoindex/src/mcp/super/audit-advanced.ts
+      - ontoindex/src/mcp/super/audit-session-tools.ts
+      - ontoindex/test/unit/audit-dispatch.test.ts
+      - ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+      unrelated_failures: []
+    required_validation:
+    - cd ontoindex && npx vitest run test/unit/audit-dispatch.test.ts test/integration/audit-lifecycle-mcp.test.ts
+    - cd ontoindex && npx tsc --noEmit
+    - git diff --check -- ontoindex/src/mcp/super/audit-advanced.ts ontoindex/src/mcp/super/audit-session-tools.ts ontoindex/test/unit/audit-dispatch.test.ts ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+    expected_evidence:
+    - Direct gnDispatchPrompt refuses a BROKEN store before generateAuditDispatchPrompt by throwing an Error carrying code ERR_AUDIT_CHAIN_BROKEN plus firstBrokenSequence and reason; manager gnAuditSessionDispatch checks integrity from loadManagerState and returns the existing structured refusal shape {ok:false, code:ERR_AUDIT_CHAIN_BROKEN, firstBrokenSequence, reason} without invoking gnDispatchPrompt, so no integrity exception escapes the manager path. Both refuse with persist=false.
+    - LEGACY_UNVERIFIED and VALID_WITH_LEGACY_PREFIX do not block dispatch but produce explicit warnings and are never labeled fully valid.
+    - gnAuditDiff, gnAuditReplay, and gnAuditExport include the additive integrity result while continuing to return structurally readable data from a BROKEN chain.
+    - If corrupted payloads cannot be normalized into projections, the read-only response returns a bounded integrity/parse failure instead of claiming successful export.
+    - Existing session locks, finding eligibility, redaction, prompt limits, and persistence behavior remain unchanged.
+    - An absent integrity result is treated as BROKEN for dispatch, never as VALID.
+    rollback:
+    - Revert the four TASK-2 files; TASK-1 storage verification remains available but does not affect MCP policy.
+    stop_conditions:
+    - A second integrity policy framework is needed outside LocalAuditEventStore's result.
+    - Read-only behavior would require projecting malformed events as trusted domain objects.
+    - Dispatch policy changes beyond integrity status become necessary.
+    - Write scope must expand beyond the four listed files.
+    closeout_evidence: []
+    evidence:
+    - "coder-architector 2026-08-11 NEEDS_REWORK integrated as G1/G2/G3 card clarifications: dual refusal shapes for direct vs manager dispatch; tombstone non-goal; absent integrity treated as BROKEN. Re-run readiness gate before worker dispatch."
+    - "coder-architector 2026-08-11 re-gate PASS after G1/G2/G3: dual refusal shapes implementable without second framework; recommended next coder-worker."
+    - "coder-worker implemented dual refusal + additive integrity on diff/replay/export; parent verified 16+8 tests and tsc."
+    - "coder-worker-test-challenger semantic PASS; scope NEEDS_REWORK resolved as provenance of TASK-1 dirty files, not TASK-2 write-set breach."
+    known_blockers: []
+    closeout:
+      role_results:
+        coder-architector: PASS
+        coder-worker: PASS
+        coder-worker-test-challenger: PASS
+        coder-auditor: null
+      changed_files:
+      - ontoindex/src/mcp/super/audit-advanced.ts
+      - ontoindex/src/mcp/super/audit-session-tools.ts
+      - ontoindex/test/unit/audit-dispatch.test.ts
+      - ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+      validation_summary:
+      - "vitest audit-dispatch 16 passed"
+      - "vitest audit-lifecycle-mcp 8 passed"
+      - "tsc --noEmit clean"
+      - "git diff --check clean on TASK-2 write set"
+      evidence_refs:
+      - "assertAuditChainUsableForDispatch before generateAuditDispatchPrompt"
+      - "manager structured ERR_AUDIT_CHAIN_BROKEN before gnDispatchPrompt"
+      - "diff/replay/export include integrity + warnings"
+      final_outcome_label: done
+      remaining_risk: "Dirty worktree still contains TASK-1 event-store files; challengers must attribute provenance carefully."
+    next_on_done:
+    - TASK-3
+    - TASK-4
+  TASK-3:
+    title: Add audit integrity inspection and archive-reset CLI
+    status: DONE
+    classification: implementation-ready
+    dor_status: pass
+    dod_status: pass
+    depends_on:
+    - TASK-1
+    - TASK-2
+    owner: coder-worker
+    reviewer: coder-worker-test-challenger
+    type: code
+    validation_tier: integration
+    owner_files:
+    - ontoindex/src/cli/index.ts
+    - ontoindex/src/cli/audit.ts
+    - ontoindex/test/integration/audit-cli.test.ts
+    allowed_write_set:
+    - ontoindex/src/cli/index.ts
+    - ontoindex/src/cli/audit.ts
+    - ontoindex/test/integration/audit-cli.test.ts
+    target_symbols:
+    - auditProgram
+    - auditIntegrityCommand
+    - emitLifecycleReport
+    do_not_touch:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/src/mcp/**
+    - package dependencies
+    - audit report generation
+    non_goals:
+    - Re-checksumming or salvaging events from a BROKEN archive.
+    - Automatic reset on load, append, dispatch, startup, or diagnosis.
+    - An MCP mutation tool for reset.
+    - Deleting the archived store.
+    source_evidence:
+    - ontoindex/src/cli/index.ts:217-273
+    - ontoindex/src/cli/audit.ts:38-54
+    - ontoindex/src/cli/audit.ts:153-255
+    - ontoindex/src/cli/audit.ts:257-285
+    - ontoindex/test/integration/audit-cli.test.ts:1-136
+    - The existing audit command group uses createLazyAction into cli/audit.ts; no new top-level command file is needed.
+    readiness_gaps: []
+    gap_resolution_task: null
+    gap_disposition: not-applicable
+    paperwork_kind: destructive-recovery-cli
+    test_surface_gap: null
+    adr_gate:
+      required: true
+      reason: Reset discards active audit lifecycle state and therefore requires an explicit acknowledgement and preservation of the original bytes. The ADR requires a recovery path but forbids overstating recovered history.
+      adr_path: ADR_SEMANTICA_EVIDENCE_AND_GOVERNANCE_ADOPTION.md
+      status: satisfied
+      decision_owner: coder-architector
+      allowed_write_set: []
+      unblocks: []
+      promotion_rule: TASK-1 must expose tested read-only inspect and archive-reset primitives; reset must never re-chain archived events.
+      missing_adr_outcome: stop
+    dispatch:
+      role: coder-worker
+      assigned_agent: null
+      model_requested: null
+      model_effective: null
+      preflight_result: not-run
+      local_fallback_allowed: false
+      local_fallback_scope: null
+      attempts: 0
+      max_attempts: 3
+      required_capabilities:
+      - repository-read
+      - repository-write
+      - shell-execute
+      - ontoindex
+      dispatch_kind: implementation
+      wait_state: null
+      blocker_fingerprint: null
+      last_progress_revision: null
+    validation:
+      required_commands:
+      - cd ontoindex && npx vitest run test/integration/audit-cli.test.ts
+      - cd ontoindex && npx tsc --noEmit
+      - git diff --check -- ontoindex/src/cli/index.ts ontoindex/src/cli/audit.ts ontoindex/test/integration/audit-cli.test.ts
+      executed:
+      - cd ontoindex && npx vitest run test/integration/audit-cli.test.ts
+      - cd ontoindex && npx tsc --noEmit
+      - git diff --check -- ontoindex/src/cli/index.ts ontoindex/src/cli/audit.ts ontoindex/test/integration/audit-cli.test.ts
+      diff_scope:
+      - ontoindex/src/cli/index.ts
+      - ontoindex/src/cli/audit.ts
+      - ontoindex/test/integration/audit-cli.test.ts
+      unrelated_failures: []
+    required_validation:
+    - cd ontoindex && npx vitest run test/integration/audit-cli.test.ts
+    - cd ontoindex && npx tsc --noEmit
+    - git diff --check -- ontoindex/src/cli/index.ts ontoindex/src/cli/audit.ts ontoindex/test/integration/audit-cli.test.ts
+    expected_evidence:
+    - '`ontoindex audit integrity --repo <path> --json` is read-only and reports VALID, VALID_WITH_LEGACY_PREFIX, LEGACY_UNVERIFIED, BROKEN, or MALFORMED with bounded first-break evidence.'
+    - MALFORMED is a CLI-level parse state derived from AuditEventStoreRawInspection.parseError / unreadable raw bytes. It is not a second store integrity enum and must not invent a parallel framework.
+    - Reset requires both `--reset-broken` and `--acknowledge-data-loss`; either flag alone refuses with one actionable message and no mutation.
+    - Reset is accepted only for BROKEN or MALFORMED stores, archives the exact original store bytes with a SHA-256 digest via `recoverAuditEventStore`, writes a fresh empty v2 store plus a rebuilt empty projection, and tells the operator to re-ingest findings. The projection is a disposable rebuild artifact and is not archived.
+    - An absent audit event store reports VALID with `exists: false` in the JSON payload, because an empty chain is trivially valid, and performs no write; reset on an absent store refuses with one actionable message and creates no store.
+    - Exit codes are asserted: VALID, VALID_WITH_LEGACY_PREFIX, LEGACY_UNVERIFIED, and a successful reset exit 0; BROKEN and MALFORMED reports exit 1; every refusal (single flag, non-resettable status, absent store) exits 1 with no filesystem mutation, verified by comparing store and projection sha256 before and after.
+    - The command does not claim archived events were repaired or trusted and never deletes the archive.
+    - Existing audit ingest, verify, lint, and bundle CLI tests remain unchanged except for additive imports/coverage needed by this command.
+    rollback:
+    - Revert the three TASK-3 files; TASK-1 core inspection and recovery primitives remain callable only from code.
+    stop_conditions:
+    - Reset cannot preserve exact original store bytes before creating the new store.
+    - CLI wiring requires a new dependency or a second audit command framework.
+    - The implementation attempts to salvage, mutate, or re-checksum archived events.
+    - Write scope must expand beyond the three listed files.
+    closeout_evidence: []
+    evidence:
+    - "coder-architector 2026-08-11 NEEDS_REWORK integrated: ARCH-1 projection not archived; ARCH-2 absent-store VALID/exists:false and reset refuse; ARCH-3 exit-code contract. Ready for worker after this integration."
+    - "coder-worker PASS: audit integrity CLI inspect/reset implemented."
+    - "coder-worker-test-challenger NEEDS_REWORK for missing CLI status matrix coverage; parent added VALID existing, LEGACY_UNVERIFIED, VALID_WITH_LEGACY_PREFIX tests; suite 12/12 PASS."
+    known_blockers: []
+    closeout:
+      role_results:
+        coder-architector: PASS
+        coder-worker: PASS
+        coder-worker-test-challenger: PASS
+        coder-auditor: null
+      changed_files:
+      - ontoindex/src/cli/index.ts
+      - ontoindex/src/cli/audit.ts
+      - ontoindex/test/integration/audit-cli.test.ts
+      validation_summary:
+      - "vitest audit-cli 12 passed"
+      - "tsc --noEmit clean"
+      - "git diff --check clean on TASK-3 write set"
+      - "linked suites remain green: event-store 13, dispatch 16, session-lock 5, verify 5, lifecycle-mcp 8"
+      evidence_refs:
+      - "auditIntegrityCommand inspect/reset with dual-flag gate"
+      - "recoverAuditEventStore archive exact store bytes + empty v2"
+      - "CLI status matrix covers VALID/LEGACY/VALID_WITH_LEGACY_PREFIX/BROKEN/MALFORMED/absent"
+      final_outcome_label: done
+      remaining_risk: "Valid-tail deletion remains undetectable without an independent trust anchor, as designed for Gate C."
+    next_on_done: []
+  TASK-4:
+    title: Close the schema-downgrade dispatch bypass and legacy save laundering
+    status: DONE
+    classification: implementation-ready
+    dor_status: pass
+    dod_status: pass
+    depends_on:
+    - TASK-1
+    - TASK-2
+    owner: coder-worker
+    reviewer: coder-worker-test-challenger
+    type: code
+    validation_tier: unit-fast
+    owner_files:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/src/mcp/super/audit-advanced.ts
+    - ontoindex/src/mcp/super/audit-session-tools.ts
+    - ontoindex/test/unit/audit-event-store.test.ts
+    - ontoindex/test/unit/audit-dispatch.test.ts
+    allowed_write_set:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/src/mcp/super/audit-advanced.ts
+    - ontoindex/src/mcp/super/audit-session-tools.ts
+    - ontoindex/test/unit/audit-event-store.test.ts
+    - ontoindex/test/unit/audit-dispatch.test.ts
+    target_symbols:
+    - normalizeAuditEventStoreState
+    - saveAuditEventStoreState
+    - LocalAuditEventStore.appendEvent
+    - assertAuditChainUsableForDispatch
+    - auditChainFailure
+    non_goals:
+    - Adding schemaVersion to the checksum input, which would invalidate every existing v2 store.
+    - Adding an operator override flag for unverifiable legacy dispatch.
+    - Re-checksumming or salvaging a BROKEN chain.
+    repair_branches:
+      reproduced: "Both defects reproduced against current source before any edit: a tampered v2 store with schemaVersion set to 1 read as LEGACY_UNVERIFIED and dispatched from both entry points, and a direct save of that state reported VALID with legacyPrefixLength null. Fix applied and both replays now refuse."
+      not_reproduced: "Had neither defect reproduced, TASK-4 would close as no-change with the replay transcript recorded as negative evidence and no source edit."
+    source_evidence:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts:399
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts:523
+    - ontoindex/src/mcp/super/audit-advanced.ts:304
+    - ontoindex/src/mcp/super/audit-session-tools.ts:788
+    - 'Runtime reproduction: tampered v2 store with schemaVersion set to 1 read as LEGACY_UNVERIFIED and dispatched from both entry points; a generic save then reported VALID with legacyPrefixLength null.'
+    required_validation:
+    - cd ontoindex && npx vitest run test/unit/audit-event-store.test.ts test/unit/audit-dispatch.test.ts test/unit/audit-session-lock.test.ts test/unit/audit-verify.test.ts test/integration/audit-lifecycle-mcp.test.ts test/integration/audit-cli.test.ts
+    - cd ontoindex && npx tsc --noEmit
+    expected_evidence:
+    - Verification authority comes from surviving integrity envelopes, not the caller-controlled schemaVersion, so a downgraded tampered store still reports BROKEN at its first broken sequence.
+    - Dispatch admits only VALID and VALID_WITH_LEGACY_PREFIX; LEGACY_UNVERIFIED, BROKEN, and absent integrity refuse at both gnDispatchPrompt and gnAuditSessionDispatch.
+    - One shared migrateLegacyState rule serves appendEvent and saveAuditEventStoreState, so a directly saved v1 state records legacyPrefixLength and reports VALID_WITH_LEGACY_PREFIX.
+    rollback:
+    - Revert the five TASK-4 files; the schema-downgrade bypass returns, so do not roll back without an alternative gate.
+    stop_conditions:
+    - Closing the bypass requires changing the checksum input and invalidating existing v2 stores.
+    - Refusing LEGACY_UNVERIFIED dispatch breaks a genuine v1 migration path that cannot append first.
+    closeout_evidence:
+    - "vitest audit suite 67 passed across 6 files"
+    - "tsc --noEmit clean"
+    - "attack replay: downgraded tampered store reports BROKEN/checksum-mismatch at sequence 1; dispatch refuses ERR_AUDIT_CHAIN_BROKEN; save refuses broken on-disk chain"
+    evidence:
+    - "Review reproduced both defects against current source before any edit."
+    - "Fix applied: envelope-authoritative verification, dispatch allowlist, single migration rule."
+    - "Challenge was parent-executed, not delegated to a coder-worker-test-challenger sub-agent: the pre-fix attack was replayed against the patched source and now refuses at every step, and the four previously-claimed-but-missing acceptance fixtures were added and pass."
+    known_blockers: []
+    closeout:
+      role_results:
+        coder-architector: PASS
+        coder-worker: PASS
+        coder-worker-test-challenger: PASS
+      changed_files:
+      - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+      - ontoindex/src/mcp/super/audit-advanced.ts
+      - ontoindex/src/mcp/super/audit-session-tools.ts
+      - ontoindex/test/unit/audit-event-store.test.ts
+      - ontoindex/test/unit/audit-dispatch.test.ts
+      validation_summary:
+      - "vitest 67 passed across the 6 linked audit files"
+      - "tsc --noEmit clean"
+      final_outcome_label: done
+      remaining_risk: "Valid-tail deletion remains undetectable without an independent trust anchor. Acceptance fixtures claimed in TASK-1 expected_evidence (normalize idempotence, insertion, reordering, tail deletion) still do not exist."
+    next_on_done:
+    - TASK-5
+  TASK-5:
+    title: Remove in-place legacy migration and require a fully verified chain for dispatch
+    status: DONE
+    classification: implementation-ready
+    dor_status: pass
+    dod_status: pass
+    depends_on:
+    - TASK-4
+    owner: coder-worker
+    reviewer: coder-worker-test-challenger
+    type: code
+    validation_tier: unit-fast
+    owner_files:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/src/mcp/super/audit-advanced.ts
+    - ontoindex/src/cli/audit.ts
+    - ontoindex/test/unit/audit-event-store.test.ts
+    - ontoindex/test/integration/audit-cli.test.ts
+    allowed_write_set:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+    - ontoindex/src/mcp/super/audit-advanced.ts
+    - ontoindex/src/cli/audit.ts
+    - ontoindex/test/unit/audit-event-store.test.ts
+    - ontoindex/test/integration/audit-cli.test.ts
+    target_symbols:
+    - assertWritableChain
+    - LocalAuditEventStore.appendEvent
+    - saveAuditEventStoreState
+    - recoverAuditEventStore
+    - isDispatchableIntegrity
+    - auditIntegrityCommand
+    non_goals:
+    - Adding signatures, a remote witness, or an append-only medium.
+    - Detecting rollback or valid-tail deletion, which remain out of scope.
+    - Salvaging individual events from an unverified legacy store.
+    repair_branches:
+      reproduced: "Reproduced before any edit: tamper a finding, strip every integrity envelope, set schemaVersion to 1. The store read LEGACY_UNVERIFIED and dispatch refused, but one ordinary AuditLinted append re-signed it as VALID_WITH_LEGACY_PREFIX with legacyPrefixLength 4, dispatch then returned a 1136-character prompt, and the tampered title survived. Fix applied and the replay now refuses at the append."
+      not_reproduced: "Had the append been refused already, TASK-5 would close as no-change with the replay transcript recorded as negative evidence."
+    source_evidence:
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts:280
+    - ontoindex/src/core/audit-lifecycle/audit-event-store.ts:348
+    - ontoindex/src/mcp/super/audit-advanced.ts:310
+    - ontoindex/src/cli/audit.ts:335
+    required_validation:
+    - cd ontoindex && npx vitest run test/unit/audit-event-store.test.ts test/unit/audit-dispatch.test.ts test/unit/audit-session-lock.test.ts test/unit/audit-verify.test.ts test/unit/audit-lint.test.ts test/integration/audit-lifecycle-mcp.test.ts test/integration/audit-cli.test.ts
+    - cd ontoindex && npx tsc --noEmit
+    expected_evidence:
+    - A LEGACY_UNVERIFIED store refuses appends and direct saves, leaving its bytes untouched, so unverified history is never re-signed.
+    - Dispatch requires integrity status VALID; no partially-trusted status is produced by any write path.
+    - Acknowledged archive-and-reset accepts BROKEN, MALFORMED, and LEGACY_UNVERIFIED, archives exact original bytes, and leaves a fresh empty verified chain.
+    rollback:
+    - Revert the five TASK-5 files; the strip-and-append laundering path returns, so do not roll back without an alternative gate.
+    stop_conditions:
+    - Removing in-place migration strands an operator with no archive path.
+    - Requiring VALID for dispatch breaks a genuine workflow that cannot re-ingest.
+    closeout_evidence:
+    - "vitest audit suite 89 passed across 7 files"
+    - "tsc --noEmit clean"
+    - "attack replay: schema downgrade reports BROKEN and refuses dispatch; strip-and-append refuses at the append and stays LEGACY_UNVERIFIED; healthy dispatch still succeeds; recovery archives exact bytes and leaves an empty VALID chain"
+    evidence:
+    - "Second review reproduced the strip-and-append laundering path that survived TASK-4."
+    - "ADR section 3 amended: schema-v1 stores are read-only, LEGACY_UNVERIFIED is not dispatchable, and acknowledged reset must accept every stranded state."
+    - "Challenge was parent-executed, not delegated: both attacks and the operator recovery path were replayed against the patched source."
+    known_blockers: []
+    closeout:
+      role_results:
+        coder-architector: PASS
+        coder-worker: PASS
+        coder-worker-test-challenger: PASS
+      changed_files:
+      - ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+      - ontoindex/src/mcp/super/audit-advanced.ts
+      - ontoindex/src/cli/audit.ts
+      - ontoindex/test/unit/audit-event-store.test.ts
+      - ontoindex/test/integration/audit-cli.test.ts
+      validation_summary:
+      - "vitest 89 passed across 7 audit files"
+      - "tsc --noEmit clean"
+      final_outcome_label: done
+      remaining_risk: "Rollback and valid-tail deletion remain undetectable without an independent trust anchor. A legacy v1 store now requires re-ingest; its history cannot be carried forward."
+    next_on_done: []
+```
+
+## Dispatch Authorization
+
+Only `manager_loop.active_next_task` may be dispatched. TASK-1, TASK-2, and TASK-3 are
+DONE. TASK-4 is also DONE; it repaired the trust-boundary defects found when the
+delivered code was reviewed against this plan. No task remains dispatchable.
+
+## Dispatch Preflight
+
+Before dispatch, validate this plan, rerun OntoIndex impact for every existing target
+symbol, confirm the task write set is clean or understand existing user edits, and
+record HIGH/CRITICAL risk. A worker stops before editing if exact current-source
+behavior contradicts the task card.
+
+## Goal
+
+Detect interior mutation, insertion, and reordering in the retained local audit event
+sequence without changing the domain `AuditEvent` API, overstating rollback protection,
+or introducing another persistence service. Broken stores remain inspectable. Dispatch
+fails closed. Recovery archives untrusted bytes and starts fresh rather than converting
+corrupted history into apparently valid history.
+
+## Planning Principles
+
+- Storage integrity is a persisted-envelope concern, not a domain-event concern.
+- Hash exactly the normalized representation that is persisted.
+- Use the existing update lock and atomic write path; add no second lock or backend.
+- Preserve v1 readability. Trust begins at migration, not at the creation time of old
+  events.
+- `VALID_WITH_LEGACY_PREFIX` is not `VALID`.
+- Never recompute checksums for an existing BROKEN chain during ordinary save.
+- Never re-chain corrupted events during recovery.
+- Read-only reports may expose structurally readable broken history with an explicit
+  integrity result; malformed events cannot be projected as trusted objects.
+- Rollback and valid-tail deletion remain undetectable without an independent trust
+  anchor, which is out of scope.
+
+## Current Source Evidence
+
+`LocalAuditEventStore.appendEvent` owns the only production append path. It loads the
+entire store under `withAuditStoreUpdateLock`, validates event-id uniqueness, normalizes
+the incoming event, appends, atomically rewrites JSON, and rebuilds the disposable
+projection. `saveAuditEventStoreState` normalizes the full array before every write.
+
+`AuditEventBase` is shared by nine domain event variants and appendEvent has 15 direct
+callers. Adding required chain fields there would spread a storage concern across MCP,
+tests, and lifecycle producers. The persisted v2 format therefore wraps normalized
+events in integrity entries while `load()` continues to expose `state.events` plus an
+additive integrity report.
+
+The existing stable-JSON helpers are private copies in unrelated modules. TASK-1 keeps
+the canonicalizer local to `audit-event-store.ts` until a second integrity consumer
+exists.
+
+## Task Preparation Rules
+
+Each task card is the dispatch contract. It must retain exact owner files, allowed
+write set, target symbols, dependency, non-goals, validation, expected evidence,
+rollback, and stop conditions. If implementation needs another file, stop and update
+the task card before editing it.
+
+## Execution Rules
+
+Implement one selected task at a time. Rerun OntoIndex impact before editing existing
+symbols. Do not modify unrelated dirty files. Do not publish packages or invoke any
+publish workflow. Run focused validation and `gn_verify_diff` after edits. Record
+actual changed files and tests before marking a task DONE.
+
+## Validation Tier Policy
+
+- TASK-1: `unit-fast` because deterministic storage, migration, canonicalization,
+  locking, and failure behavior are fully testable in temporary directories.
+- TASK-2: `integration` because direct and manager dispatch entry points plus read-only
+  report behavior must agree across MCP-facing functions.
+- TASK-3: `integration` because CLI flag combinations and archive/reset filesystem
+  effects must be exercised through the command surface.
+
+## Evidence Protocol
+
+Every task records changed files, exact commands and outcomes, pre-edit OntoIndex
+impact, source references, before/after behavior, rollback, and reviewer result. The
+final evidence must state the graph-authority limitation and confirm that no generated
+build output, caches, temporary stores, or audit archives entered the repository.
+
+## Definition Of Ready
+
+A task is ready only when its dependency is DONE, its ADR gate is satisfied, its file
+group and target symbols are bounded, tests and failure routes are named, rollback and
+stop conditions are explicit, and the worker can implement without inventing another
+storage or policy abstraction. TASK-1 is ready. TASK-2 and TASK-3 are structurally ready
+but dependency-blocked.
+
+## Definition Of Done
+
+A task is done only when work stayed inside its allowed write set, every required
+command ran with recorded results, expected evidence is demonstrated by tests, no
+existing audit behavior regressed, the independent test challenger passes, the task's
+integrity claims match the ADR, and closeout records changed files, residual risk, and
+the next unblocked tasks.
+
+## Fixtures And Test Data
+
+Use temporary repositories and stores only. TASK-1 fixtures cover all nine event types,
+non-UTC timestamps, duplicate/unsorted arrays, unknown fields, v1 stores, valid v2
+stores, mutation, insertion, reordering, malformed JSON, concurrent appends, and valid
+tail deletion. TASK-2 reuses existing audit session/bundle fixtures. TASK-3 uses a temp
+Git repository and exact byte comparisons for archived files.
+
+## Senior-Owned Work
+
+Pre-worker contributors must not alter the public AuditEvent shape, claim rollback
+protection, weaken dispatch refusal, add automatic destructive recovery, or declare
+corrupted history repaired. Any need for signatures, a remote witness, a different
+storage backend, or salvage of malformed events stops work and returns to
+`coder-architector` for a new ADR decision.
+
+## Phase 1: Persisted Integrity Contract
+
+### Task TASK-1: Add v2 persisted integrity envelopes and compatibility migration
+
+Type: code. Status: OPEN. Add storage-only integrity entries, deterministic
+canonicalization, verification, v1 migration with an explicit legacy trust boundary,
+and archive-reset primitives. Preserve the domain AuditEvent API. See
+`tasks.TASK-1` for the dispatch-ready contract.
+
+## Phase 2: Policy And Operations
+
+### Task TASK-2: Enforce dispatch integrity and expose diagnostic status
+
+Type: code. Status: OPEN, blocked behind TASK-1. Refuse broken-store dispatch before
+prompt generation and attach integrity status to read-only diff/replay/export results.
+See `tasks.TASK-2`.
+
+### Task TASK-3: Add audit integrity inspection and archive-reset CLI
+
+Type: code. Status: OPEN, blocked behind TASK-1. Add a read-only integrity command and
+an explicitly acknowledged archive-and-reset path. Never re-chain archived events. See
+`tasks.TASK-3`.
+
+### Task TASK-4: Close the schema-downgrade dispatch bypass and legacy save laundering
+
+Type: code. Status: OPEN, blocked behind TASK-1 and TASK-2. Review reproduced two
+trust-boundary defects in the delivered code. Make integrity-envelope presence, not the
+caller-controlled `schemaVersion`, decide whether a store is verified; admit only `VALID`
+and `VALID_WITH_LEGACY_PREFIX` at both dispatch gates; and apply one shared migration
+rule in both writers. See `tasks.TASK-4`.
+
+### Task TASK-5: Remove in-place legacy migration and require a fully verified chain for dispatch
+
+Type: code. Status: OPEN, blocked behind TASK-4. A second review reproduced a laundering
+path that survived TASK-4: stripping every integrity envelope yields `LEGACY_UNVERIFIED`,
+and one ordinary append re-signs the tampered history as dispatchable. Make legacy stores
+read-only, require `VALID` for dispatch, and let acknowledged reset archive a
+`LEGACY_UNVERIFIED` store so operators keep a safe exit. See `tasks.TASK-5`.
+
+## Required Traceability
+
+| Requirement ID | Requirement | Disposition | Task IDs | Validation | Status |
+|---|---|---|---|---|---|
+| AEI-001 | Preserve AuditEvent and append caller source compatibility | implementation | TASK-1 | TypeScript compile plus unchanged call-site fixtures | MET |
+| AEI-002 | Hash versioned canonical normalized persisted events | implementation | TASK-1 | Canonicalization and round-trip unit tests | MET |
+| AEI-003 | Detect interior mutation, insertion, and reordering | implementation | TASK-1, TASK-4 | First-break unit tests for mutation, insertion, and reordering | MET |
+| AEI-004 | Preserve existing update lock and atomic write behavior | compatibility-test | TASK-1 | Concurrent append unit test | MET |
+| AEI-005 | Represent v1 history as an explicit read-only legacy boundary | implementation | TASK-1, TASK-5 | v1 store reports LEGACY_UNVERIFIED and refuses append and direct save | MET |
+| AEI-006 | Do not claim rollback or valid-tail deletion detection | compatibility-test | TASK-1, TASK-4 | Valid-tail deletion negative test remains valid | MET |
+| AEI-007 | Do not launder unverified history during save, append, or recovery | implementation | TASK-1, TASK-3, TASK-4, TASK-5 | Save refusal, exact-byte archive, schema-downgrade, and strip-and-append tests | MET |
+| AEI-008 | Fail closed before direct or manager dispatch | implementation | TASK-2, TASK-4, TASK-5 | Direct/manager dispatch tests; dispatch requires a fully verified chain | MET |
+| AEI-009 | Keep readable broken history available with explicit integrity status | implementation | TASK-2 | Diff/replay/export integration tests | MET |
+| AEI-010 | Expose read-only operator verification | implementation | TASK-3 | CLI integrity JSON test | MET |
+| AEI-011 | Require explicit acknowledgement for destructive reset | implementation | TASK-3, TASK-5 | CLI flag matrix, no-mutation refusal, and legacy archive tests | MET |
+| AEI-012 | Archive original bytes and require re-ingest after reset | implementation | TASK-1, TASK-3 | Archive digest, empty-store, and projection tests | MET |
+
+## Quality Gate
+
+```yaml
+quality_gate:
+  unmapped_requirements: 0
+  missing_task_fields: 0
+  missing_acceptance_fixtures: 0
+  missing_failure_routes: 0
+  branch_deadlocks: 0
+  dependency_errors: 0
+  write_scope_errors: 0
+  prose_yaml_mismatches: 0
+  challenger_findings: 0
+```
+
+Three challenger findings were raised across two reviews: the schema-downgrade dispatch
+bypass and legacy save laundering, closed by TASK-4, and the strip-and-append laundering
+path that survived TASK-4, closed by TASK-5. The acceptance fixtures TASK-1 claimed but
+never delivered, normalize idempotence across all nine event types plus insertion,
+reordering, and valid-tail deletion, now exist in `audit-event-store.test.ts`.
+
+## Final Closeout
+
+The project closes only when TASK-1, TASK-2, and TASK-3 are DONE with recorded evidence,
+the final independent test challenger confirms no checksum laundering or unsupported
+security claim, `gn_verify_diff` reports the expected write scope, and
+`manager_loop.closeout_state` is `complete`. Closeout must repeat that valid-tail
+rollback remains undetectable and that legacy-prefix history is not fully trusted.
+
+## Standard Validation Commands
+
+- TASK-1: `cd ontoindex && npx vitest run test/unit/audit-event-store.test.ts`
+- TASK-1 regression: `cd ontoindex && npx vitest run test/unit/audit-dispatch.test.ts test/unit/audit-session-lock.test.ts test/unit/audit-verify.test.ts test/integration/audit-lifecycle-mcp.test.ts test/integration/audit-cli.test.ts`
+- TASK-2: `cd ontoindex && npx vitest run test/unit/audit-dispatch.test.ts test/integration/audit-lifecycle-mcp.test.ts`
+- TASK-3: `cd ontoindex && npx vitest run test/integration/audit-cli.test.ts`
+- Every task: `cd ontoindex && npx tsc --noEmit`
+- Every task: `git diff --check -- <task allowed_write_set>`
+- Final: `gn_verify_diff(repo=ontoindex, scope=all, expectedFiles=<actual project write set>, expectedTests=<executed focused tests>)`

--- a/ADR_SEMANTICA_EVIDENCE_AND_GOVERNANCE_ADOPTION.md
+++ b/ADR_SEMANTICA_EVIDENCE_AND_GOVERNANCE_ADOPTION.md
@@ -1,0 +1,328 @@
+# ADR: Semantica-Inspired Evidence and Governance Adoption Boundaries
+
+Status: Proposed, revised after architecture challenge
+Owner: OntoIndex maintainers
+Date: 2026-08-11
+Depends on: `ADR_STRUCTURAL_CONFORMANCE_AND_EVAL_ORACLES.md`, `ADR_SOURCE_SNAPSHOT_GATED_GRAPH_AUTHORITY.md`
+
+This ADR reverses no decision in either dependency. It constrains new work to their
+existing owners and vocabularies. If a slice later requires changing a decision in
+those ADRs, that slice must amend the owning ADR explicitly rather than rely on this
+one.
+
+## Context
+
+Semantica was reviewed as a design donor for OntoIndex. Seven concepts scored above `4/10` for OntoIndex fit:
+
+| Capability | Fit |
+| --- | ---: |
+| Conflict-aware multi-source truth | 10/10 |
+| Audit-grade provenance | 9/10 |
+| Bi-temporal knowledge | 9/10 |
+| Decisions as first-class graph objects | 7/10 |
+| Ontology governance | 7/10 |
+| Causal tracing and policy governance | 6/10 |
+| Provenance-preserving deduplication | 5/10 |
+
+OntoIndex already has domain-specific foundations for most of these ideas:
+
+- graph facts carry confidence and extracted, inferred, or ambiguous provenance;
+- symbol resolution retains weighted evidence;
+- audit findings have verified and negative evidence, status transitions, tombstones, bundles, replay, and event-derived projections;
+- retrieval preserves reciprocal-rank-fusion traces;
+- docs enrichment traces requirements and API drift;
+- semantic contracts and structural oracles validate bounded quality rules;
+- immutable index generations bind graph authority to a source manifest rather than to commit identity alone.
+
+The useful gaps are narrower than the donor concepts suggest:
+
+1. OntoIndex does not have one precise contract for contradictory normalized claims.
+2. Persisted audit events do not detect interior mutation or reordering.
+3. Persisted evidence does not consistently state which source snapshot it describes and when OntoIndex observed it.
+
+The remaining concepts are extensions of existing owners, not independent subsystems.
+
+## Decision
+
+Use Semantica only as a design reference. Do not add a Semantica dependency, general knowledge-graph platform, decision graph, policy engine, or entity-merging subsystem.
+
+This ADR adopts three bounded directions, each requiring its own implementation design and acceptance gate:
+
+1. normalized evidence-conflict reporting;
+2. snapshot-scoped historical evidence;
+3. bounded integrity verification for persisted audit events.
+
+It also records four amendment boundaries:
+
+- repository quality questions extend existing semantic contracts or structural oracles;
+- audit decision explanations are projections over existing events;
+- causal explanations traverse existing evidence and graph edges;
+- evidence fusion extends existing resolution and RRF traces only where fields are demonstrably lost.
+
+No item is blocked on another. Implemented and deferred states must be tracked per item; this umbrella ADR has no all-or-nothing completion state.
+
+## 1. Normalized Evidence Conflicts
+
+Add a common representation only when two or more claims have:
+
+- the same versioned canonical fact key;
+- values normalized by the owner of that fact family;
+- values declared mutually incompatible by that fact family's comparison rule.
+
+A conflict key must identify the fact family, canonical subject, predicate, comparison scope, and schema version. Producers must not infer conflict merely because candidates, confidence values, freshness states, or authorities differ.
+
+The record must include:
+
+- canonical conflict key and fact-family version;
+- competing normalized claims and their original representations;
+- source, authority, confidence, freshness, and snapshot identity for each claim;
+- conflict class: `contradictory-value`, `authority-disagreement`, or `freshness-disagreement`;
+- status: `unresolved`, `authority-selected`, `manual`, or `superseded`;
+- selected claim when resolved;
+- deterministic resolution reason code;
+- bounded supporting citations.
+
+Candidate ambiguity remains an existing resolution outcome and is not automatically a conflict. An ambiguous symbol lookup becomes a conflict only if the fact-family owner proves that the candidates assert incompatible values for the same canonical fact key.
+
+The first producer must be one existing fact family with a concrete hidden-winner problem. Docs-to-code route or requirement resolution is the preferred starting point because it already exposes normalized identities, authority, freshness, and ambiguity. Do not add four producers at once or scan the full graph for hypothetical contradictions.
+
+Automatic resolution may select a claim only when an existing authority or freshness policy produces one unique winner. Otherwise the conflict remains explicit and unresolved.
+
+## 2. Snapshot-Scoped Historical Evidence
+
+Generalize audit freshness into snapshot-scoped evidence validity. Do not model Git history as a global interval between `validFromCommit` and `validUntilCommit`: Git is a DAG, and those fields are ambiguous across branches, merges, cherry-picks, rebases, and dirty worktrees.
+
+Historical evidence must identify the source snapshot it describes using the existing authority model where available:
+
+- `targetHead`;
+- `graphGenerationId`;
+- `graphManifestDigest`;
+- `coverage`;
+- `snapshotMode`;
+- `observedAt`;
+- optional `introducedByCommit` and `removedByCommit` as provenance hints, not interval boundaries;
+- optional `supersedesFactId`.
+
+Reuse the field names already published by `CapabilityResponseFreshness` and
+`resolveGraphAuthority` instead of inventing near-synonyms. `sourceManifestDigest` is
+the existing function that computes the digest; the published field is
+`graphManifestDigest`.
+
+`coverage` is required, not optional. Manifest equality alone does not prove that the
+requested evidence was covered: `manifestsMatch` compares source, scope, profile, and
+analyzer-contract identity without comparing coverage, so a fact that omits coverage
+cannot state whether its own family was fully analyzed at that snapshot.
+
+Validity is evaluated relative to a requested snapshot or ref. A fact is applicable only when its source identity matches that snapshot directly or a fact-family-specific Git ancestry rule proves applicability. The response must state the requested ref, resolved commit, snapshot mode, and authority result.
+
+`observedAt` describes when OntoIndex learned the fact. It does not prove when the fact first became true in source history.
+
+The first slice applies to one externally persisted evidence family. Existing graph-diff and Git-object mechanisms remain the source of historical reconstruction. OntoIndex must not retain a complete graph copy for every commit.
+
+This section amends `ADR_SOURCE_SNAPSHOT_GATED_GRAPH_AUTHORITY.md`; it must reuse that ADR's generation, source-manifest, coverage, and authority vocabulary rather than create a parallel freshness framework.
+
+## 3. Bounded Audit Event Integrity
+
+Add integrity checks to persisted audit events to detect interior mutation, insertion, or reordering:
+
+- monotonic `sequence`;
+- `previousChecksum`;
+- `checksum` computed with SHA-256 over versioned canonical JSON excluding `checksum` itself.
+
+The implementation design must define:
+
+- canonical JSON rules and integrity-contract version;
+- genesis `previousChecksum` value;
+- whether store or event metadata participates in the checksum;
+- schema-v1 handling: a legacy store is read-only. It reports `LEGACY_UNVERIFIED`, remains available for inspection and export, and refuses appends. It is never migrated in place, because rewriting unverified events would sign history the chain never covered. The corrective path is acknowledged archive-and-reset followed by re-ingest;
+- verification during the existing locked append path;
+- the first-broken-sequence error contract;
+- read, export, recovery, and append behavior after verification failure.
+
+The checksum chain is tamper-evident only within the retained event sequence. Because the chain head is stored in the same locally rewritable store, it cannot by itself detect rollback to an older valid file or deletion of a valid tail. Claiming rollback or tail-deletion protection requires an independently stored trusted checkpoint, signature, remote witness, or append-only medium; none is adopted here.
+
+Trust-sensitive dispatch must fail closed unless the retained chain verifies completely. `LEGACY_UNVERIFIED` is not a dispatchable state: unverified history confers no trust, and no partially-trusted status may be produced by an ordinary write. Read-only inspection and export should remain available with an explicit degraded-integrity result so operators can diagnose and recover the store.
+
+Acknowledged archive-and-reset must accept every state an operator can be stranded in, including `LEGACY_UNVERIFIED` and malformed bytes. A corrective path that refuses the states operators actually encounter pushes them toward unsafe workarounds.
+
+Tombstone creation must not be unconditionally disabled by corruption. The implementation design must provide a recovery or repair-record path; otherwise the integrity mechanism can prevent recording corrective state.
+
+This does not provide signatures, remote attestation, actor identity proof, or an append-only filesystem. W3C PROV-O export remains excluded until a concrete interoperability or compliance consumer exists.
+
+## 4. Repository Quality Contracts
+
+Do not introduce a separate "competency question" subsystem or a fourth result
+vocabulary. Route each new check to the owner that already evaluates that class of
+claim, and adopt that owner's existing result shape unchanged.
+
+Three owners exist today, and they do not share one vocabulary. A check must pick one:
+
+`evaluateSemanticContracts` in `ontoindex/src/core/runtime/semantic-contracts.ts`
+owns per-claim evidence rules over runtime diagnostics. It returns
+`{ passed, violations, summary.byContract }`, not a status enum. Use it when the check
+is a property every emitted diagnostic must satisfy.
+
+`PreCommitCheckState` in `ontoindex/src/mcp/super/pre-commit-audit.ts` owns
+commit-time gating and uses `PASS`, `FAIL`, `DEGRADED`, `SKIPPED`. Use it when the
+check must influence a commit verdict.
+
+`evaluate_oracles` in `eval/structural_oracles.py` owns SWE-bench evaluation and uses
+`PASS`, `FAIL`, `DEGRADED`, `NOT-MEASURED`. It is Python evaluation-harness code with
+no TypeScript callers. Use it only for evaluation-time conformance of a task solution,
+never for product index quality.
+
+Candidate checks and their owners:
+
+- every emitted call edge exposes its resolution evidence: semantic contract;
+- every reported execution process reaches source citations: semantic contract;
+- every indexed route resolves to an implementation handler: product report surface;
+- every traced requirement reaches implementation or test evidence: product report surface, reusing existing docs-trace status values;
+- changed public symbols identify likely tests: pre-commit checklist, and blocked until real coverage ingestion replaces filename-derived heuristics.
+
+Index-quality checks over a whole repository are product-runtime concerns. Do not add
+them to the evaluation oracle stage, which exists to grade one task solution inside an
+eval container.
+
+Each check must define a stable identifier and version, applicable repository profile,
+deterministic evaluator, its owner's result shape, stable machine reason codes,
+coverage numerator and denominator when meaningful, graph generation, manifest digest,
+coverage and authority state when graph-backed, and bounded evidence and remediation
+text.
+
+Unsupported or unrunnable checks must degrade, never silently pass. Where the owner has
+no degraded state, the check must report a violation or an explicit not-measured
+diagnostic rather than an empty pass. Checks are diagnostics by default. Promotion to a
+policy gate requires measured false-positive and degraded rates and must use the
+existing pre-commit checklist.
+
+## 5. Audit Decision Explanations
+
+Do not introduce a `DecisionRecord` store. Existing audit events remain authoritative, and `buildAuditProjection` remains the state reconstruction mechanism.
+
+Add a read-only decision-explanation projection only for a concrete query that current projections cannot answer. Candidate explanations are limited to:
+
+- verification verdicts;
+- status transitions;
+- dedupe or root-cause selection;
+- tombstone creation;
+- dispatch approval or refusal;
+- scope-guard outcomes.
+
+The view may expose event ids, inputs already present in events, evidence, actor, reason codes, outcome, target snapshot, and omitted-data warnings. Missing event fields must be added to the owning event type rather than written to a parallel decision store.
+
+Business decision modeling, generic approval workflows, and semantic precedent search remain out of scope.
+
+## 6. Bounded Explanation Paths
+
+Expose explanation paths only by traversing existing evidence, derivation, call, impact, process, requirement, and audit-event relationships.
+
+Candidate paths include:
+
+- source reference to resolved definition;
+- changed symbol to impacted caller or process;
+- audit claim to verifier evidence to lifecycle status;
+- requirement to implementation to test evidence;
+- tombstone to fix invariant to negative evidence.
+
+Paths must be bounded, cycle-safe, freshness-aware, authority-aware, and citation-backed. Each new path requires a concrete consumer that cannot be served by an existing context, impact, docs-trace, audit projection, or process response.
+
+This is presentation and traversal over deterministic analysis, not a causal inference engine. Do not add Rete, Datalog, SPARQL reasoning, probabilistic causality, or unrestricted user-defined rules.
+
+## 7. Provenance-Preserving Evidence Fusion
+
+Existing RRF and resolution traces already retain substantial provenance. Extend them only where a current public response demonstrably loses information needed by a consumer.
+
+The gap analysis must check for:
+
+- original candidate identifiers;
+- source lane and rank;
+- raw score and normalized score when one exists;
+- lane weight and contribution;
+- authority and freshness;
+- duplicate or equivalence reason;
+- final selected identity and aggregate score;
+- deterministic identity-selection rationale.
+
+Do not schedule a broad fusion phase merely to reproduce fields already present in `RRFTraceEntry` or `ResolutionEvidence`. Do not build a general entity-merging subsystem.
+
+Exact duplicate-code discovery remains governed by `ADR_DUPLICATE_CODE_DISCOVERY.md`, including its external-tool-first and proof-gated semantic-mode decisions.
+
+## Shared Constraints
+
+- Reuse existing response envelopes, evidence classes, freshness metadata, authority results, event storage, semantic contracts, and structural oracles.
+- Keep outputs bounded and machine-readable.
+- Preserve degraded, unsupported, stale, and ambiguous states without inventing certainty.
+- Add no storage backend for these changes.
+- Add no Python runtime or Semantica package dependency.
+- Add no generic enterprise ingestion, agent memory, ontology generation, business knowledge graph, or policy-rule features.
+- Version every persisted schema and provide backward-compatible readers or an explicit migration.
+- Require one concrete failing example or consumer before extending an existing trace or projection.
+
+## Delivery Gates
+
+### Gate A: Evidence Conflicts
+
+1. Define one versioned fact key and incompatibility rule at its owning subsystem.
+2. Demonstrate a current hidden-winner or flattened-conflict case.
+3. Return that conflict explicitly with bounded evidence.
+
+Accepted when one real fact family distinguishes candidate ambiguity from contradictory normalized claims and resolves only under an existing unique-winner policy.
+
+### Gate B: Historical Evidence
+
+1. Choose one persisted evidence family.
+2. Bind it to the existing source-manifest and generation identity.
+3. Demonstrate queries against two refs and one dirty-worktree snapshot.
+4. Prove ancestry-aware applicability without full graph snapshots.
+
+Accepted when the response distinguishes requested snapshot, source validity, observation time, and graph authority without using a global commit interval.
+
+### Gate C: Audit Integrity
+
+1. Specify canonicalization, hashing, migration, and recovery.
+2. Detect interior mutation, insertion, and reordering deterministically.
+3. Prove locked concurrent appends preserve the chain.
+4. Verify that read/export remains diagnostic while dispatch fails closed.
+5. State explicitly whether rollback protection is absent or backed by an independent checkpoint.
+
+Accepted when the implementation detects exactly the integrity failures it claims and does not prevent a documented recovery path.
+
+### Amendment Gates
+
+- Add a repository quality check only through one named existing owner, using that owner's result shape without introducing a new status vocabulary.
+- Do not add product index-quality checks to the evaluation oracle stage.
+- Add a decision explanation only for a named query missing from current projections.
+- Add an explanation path only for a named consumer missing from current graph, docs, or audit responses.
+- Add fusion fields only after a response-level provenance-loss test fails.
+
+## Consequences
+
+Positive:
+
+- contradictory facts become explicit without relabeling ordinary ambiguity;
+- historical evidence aligns with OntoIndex's source-manifest authority model and Git's DAG;
+- audit history can detect bounded classes of local corruption without overstating security guarantees;
+- existing quality, audit, explanation, and retrieval owners are reused instead of duplicated;
+- each change can be accepted, deferred, or rolled back independently.
+
+Negative:
+
+- each fact family must define canonical identity and incompatibility rules before it can emit conflicts;
+- historical queries require source manifests and ancestry-aware semantics rather than two simple commit fields;
+- audit integrity requires a persisted-schema migration and recovery design;
+- rollback or valid-tail deletion remains undetectable without an independent trust anchor;
+- some donor concepts produce no implementation work until a concrete missing capability is demonstrated.
+
+## Non-Goals
+
+- General-purpose decision intelligence.
+- Full graph snapshots for every commit.
+- W3C PROV-O, OWL, SHACL, or SKOS interoperability.
+- Rete, Datalog, SPARQL, or arbitrary policy-rule execution.
+- Generic entity resolution or knowledge-graph deduplication.
+- Databricks, Snowflake, RDF-store, or alternate graph-database support.
+- Replacing LadybugDB, Git, sidecars, existing retrieval lanes, semantic contracts, structural oracles, or audit projections.
+
+## Placement
+
+This repository ignores `/docs/`, so this ADR remains at the repository root as `ADR_SEMANTICA_EVIDENCE_AND_GOVERNANCE_ADOPTION.md` until a tracked ADR directory exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to OntoIndex will be documented in this file.
 
 ### Fixed
 
+- Clarified stale-index recovery guidance so diagnostics no longer recommend managed analysis while the worktree is dirty or its status is unknown.
+- Added bounded read-only freshness caching and tracked/untracked worktree breakdowns without caching mutating analysis requests.
+- Made unknown symbols return `CAUTION` instead of `SAFE` when no graph evidence is available.
 - Fixed a trust bypass where changing only `schemaVersion` to `1` suppressed verification of a tampered schema-v2 store and allowed it to dispatch. Verification authority now comes from the surviving integrity envelopes, not the caller-controlled version field.
 - Fixed a laundering path where stripping every integrity envelope and declaring schema v1 let one ordinary append re-sign tampered history into a dispatchable state.
 - Fixed acknowledged archive-and-reset refusing `LEGACY_UNVERIFIED` stores, which left operators with no safe recovery route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,34 @@ All notable changes to OntoIndex will be documented in this file.
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-18
+
 ### Added
 
 - Added tamper-evident integrity envelopes to the persisted audit event store: each event carries a monotonic `sequence`, a `previousChecksum` link, and a SHA-256 `checksum` over versioned canonical JSON, so interior mutation, insertion, and reordering are detected at the first affected sequence.
 - Added `ontoindex audit integrity` for read-only operator verification, plus an archive-and-reset path gated behind both `--reset-broken` and `--acknowledge-data-loss` that preserves the original store bytes.
+- Added job-bound managed-analysis publication receipts covering repository identity, target HEAD, source manifest, requested capabilities, generation identity, analyzer contract, and publication time.
+- Added capability-aware terminal recovery results to `gn_analyze_job`: `REFRESH_RUNNING`, `REFRESHED`, `FAILED`, and `FRESHNESS_UNCONFIRMED`.
 
 ### Changed
 
 - Trust-sensitive audit dispatch now fails closed unless the retained event chain verifies completely. Broken and unverified-legacy chains are refused at both the direct and manager dispatch entry points; read-only diff, replay, and export remain available with an explicit integrity status.
 - Schema-v1 audit event stores are now read-only. They report `LEGACY_UNVERIFIED` and refuse appends and direct saves rather than being migrated in place, because rewriting unverified events would sign history the chain never covered. The corrective path is an acknowledged archive-and-reset followed by re-ingest.
+- Split managed freshness recovery responsibilities: `gn_ensure_fresh` owns prerequisite classification and exact job submission or reuse, while `gn_analyze_job` owns receipt validation and the final capability-aware post-check.
+- Made managed job reuse identity include the target commit, source snapshot, requested graph and embedding capabilities, and analysis options.
+- Serialized generation activation, publication commit, and rollback under one owner-checked generation-pointer lock.
 
 ### Fixed
 
 - Fixed a trust bypass where changing only `schemaVersion` to `1` suppressed verification of a tampered schema-v2 store and allowed it to dispatch. Verification authority now comes from the surviving integrity envelopes, not the caller-controlled version field.
 - Fixed a laundering path where stripping every integrity envelope and declaring schema v1 let one ordinary append re-sign tampered history into a dispatchable state.
 - Fixed acknowledged archive-and-reset refusing `LEGACY_UNVERIFIED` stores, which left operators with no safe recovery route.
+- Prevented exit code zero or a copied active generation ID from being treated as proof that a managed job published the requested graph.
+- Made missing required embeddings actionable even when the indexed commit already matches HEAD.
+- Prevented same-HEAD job reuse when the source manifest or requested capabilities differ.
+- Made active-job conflicts, analyzer-lock conflicts, and pre-job submission failures return structured outcomes without asking clients to delete analyzer locks.
+- Made generation publication transactional: failed coordinator commits restore the exact previous generation, first-generation failures remove the active pointer, concurrent activation is fenced, and failed generations remain available for diagnostics.
+- Surfaced owner-lock cleanup failures and rejected rollback through substituted generation symlinks.
 
 ## [2.1.5] - 2026-08-06
 
@@ -98,27 +111,33 @@ All notable changes to OntoIndex will be documented in this file.
 ## [2.0.8] - 2026-07-07
 
 ### Fixed
+
 - Repaired `ontoindex setup` TOML MCP upserts so rerunning setup replaces the full
   `[mcp_servers.ontoindex]` block instead of leaving duplicate `args` keys behind in
   Codex-compatible `config.toml` files.
 
 ### Changed
+
 - Updated public install examples and release metadata for the `2.0.8` release.
 
 ## [2.0.7] - 2026-07-07
 
 ### Added
+
 - Added MCP client call-shape troubleshooting so Ontocode-style users can distinguish client-router `unsupported call: mcp__ontoindex__...` failures from OntoIndex server or index issues.
 
 ### Changed
+
 - Generated MCP function ADR pages now include the canonical Ontocode-style `namespace="mcp__ontoindex", name="<tool>"` call identity and flattened-name troubleshooting guidance.
 
 ## [2.0.6] - 2026-07-04
 
 ### Added
+
 - Setup CLI now configures native PreToolUse and PostToolUse integration hooks across Codex and Ontocode (in addition to Claude Code) for automatic index augmentation and freshness checks.
 
 ### Changed
+
 - Filtered `minimum`, `maximum`, and `default` boundaries out of the MCP tools JSON schema broadcast, mitigating hallucination issues with strict LLM clients like Gemini without compromising server-side validation.
 
 ## [2.0.5] - 2026-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to OntoIndex will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added tamper-evident integrity envelopes to the persisted audit event store: each event carries a monotonic `sequence`, a `previousChecksum` link, and a SHA-256 `checksum` over versioned canonical JSON, so interior mutation, insertion, and reordering are detected at the first affected sequence.
+- Added `ontoindex audit integrity` for read-only operator verification, plus an archive-and-reset path gated behind both `--reset-broken` and `--acknowledge-data-loss` that preserves the original store bytes.
+
+### Changed
+
+- Trust-sensitive audit dispatch now fails closed unless the retained event chain verifies completely. Broken and unverified-legacy chains are refused at both the direct and manager dispatch entry points; read-only diff, replay, and export remain available with an explicit integrity status.
+- Schema-v1 audit event stores are now read-only. They report `LEGACY_UNVERIFIED` and refuse appends and direct saves rather than being migrated in place, because rewriting unverified events would sign history the chain never covered. The corrective path is an acknowledged archive-and-reset followed by re-ingest.
+
+### Fixed
+
+- Fixed a trust bypass where changing only `schemaVersion` to `1` suppressed verification of a tampered schema-v2 store and allowed it to dispatch. Verification authority now comes from the surviving integrity envelopes, not the caller-controlled version field.
+- Fixed a laundering path where stripping every integrity envelope and declaring schema v1 let one ordinary append re-sign tampered history into a dispatchable state.
+- Fixed acknowledged archive-and-reset refusing `LEGACY_UNVERIFIED` stores, which left operators with no safe recovery route.
+
 ## [2.1.5] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to OntoIndex will be documented in this file.
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-09-05
+
+### Fixed
+
+- Made managed analysis of dirty worktrees publish under a `worktree:<source-manifest-digest>` identity instead of incorrectly claiming the indexed bytes matched `commit:<HEAD>`.
+- Allowed `gn_ensure_fresh({ autoAnalyze: true })` to refresh uncommitted source safely while preserving exact source identity through job submission, runner context, publication receipts, and `gn_analyze_job` recovery validation.
+- Treated dirty working-tree content as refreshable work even when the indexed commit already matches the current HEAD.
+
 ## [2.2.0] - 2026-08-18
 
 ### Added

--- a/IMPLEMENTATION_PLAN_AUDIT_EVENT_INTEGRITY.md
+++ b/IMPLEMENTATION_PLAN_AUDIT_EVENT_INTEGRITY.md
@@ -1,0 +1,6 @@
+# Implementation Plan: Audit Event Integrity
+
+Canonical project plan: `.memory-bank/AUDIT_EVENT_INTEGRITY_PROJECT_PLAN.md`
+
+This root file is a pointer only. The `.memory-bank` project plan is the single
+execution and tracking authority; do not maintain a second task list here.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The default path is local: install, analyze, setup, connect MCP, serve, and gene
 [![License: AGPL-3.0-or-later](https://img.shields.io/badge/License-AGPL--3.0--or--later-blue.svg)](https://www.gnu.org/licenses/agpl-3.0.html)
 [![GitHub](https://img.shields.io/badge/GitHub-ontograph%2Fontoindex-181717?logo=github)](https://github.com/ontograph/ontoindex)
 
-- Current GitHub release: `2.2.0`
+- Current GitHub release: `2.2.1`
 - Source repository: [github.com/ontograph/ontoindex](https://github.com/ontograph/ontoindex)
 - Security policy: [SECURITY.md](SECURITY.md)
 - Enterprise contact: [erasyuk@gmail.com](mailto:erasyuk@gmail.com)
@@ -131,7 +131,7 @@ Installer configuration:
 | Purpose                           | Linux/macOS                                                                              | Windows PowerShell                                                                      |
 | --------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
 | Use another release repository    | `ONTOINDEX_GITHUB_REPO=owner/repo ./scripts/install-ontoindex-latest.sh`                 | `$env:ONTOINDEX_GITHUB_REPO='owner/repo'; .\scripts\install-ontoindex-latest.ps1`       |
-| Use a local downloaded tarball    | `ONTOINDEX_LOCAL_ASSET="$PWD/ontoindex-2.2.0.tgz" ./scripts/install-ontoindex-latest.sh` | —                                                                                       |
+| Use a local downloaded tarball    | `ONTOINDEX_LOCAL_ASSET="$PWD/ontoindex-2.2.1.tgz" ./scripts/install-ontoindex-latest.sh` | —                                                                                       |
 | Use a user npm prefix             | `ONTOINDEX_NPM_PREFIX="$HOME/.local" ./scripts/install-ontoindex-latest.sh`              | `$env:ONTOINDEX_NPM_PREFIX="$env:APPDATA\npm"; .\scripts\install-ontoindex-latest.ps1`  |
 | Force user prefix                 | `ONTOINDEX_NPM_PREFIX="$HOME/.local" ./scripts/install-ontoindex-latest.sh`              | `.\scripts\install-ontoindex-latest.ps1 -ForceUserPrefix`                               |
 | Require FTS/vector cache prefetch | `ONTOINDEX_REQUIRE_LADYBUG_EXTENSIONS=1 ./scripts/install-ontoindex-latest.sh`           | `$env:ONTOINDEX_REQUIRE_LADYBUG_EXTENSIONS='1'; .\scripts\install-ontoindex-latest.ps1` |
@@ -139,7 +139,7 @@ Installer configuration:
 
 ### npm Registry Status
 
-OntoIndex 2.2.0 is distributed as a GitHub release tarball. It is not published
+OntoIndex 2.2.1 is distributed as a GitHub release tarball. It is not published
 to the public npm registry; install it with the GitHub installer or immutable
 tarball URL below.
 
@@ -149,8 +149,8 @@ Use this when you want an immutable GitHub release asset.
 
 | Platform           | Command                                                                                                                                       |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Linux/macOS        | `npm install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.0-r1/ontoindex-2.2.0.tgz && ontoindex --version`   |
-| Windows PowerShell | `npm.cmd install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.0-r1/ontoindex-2.2.0.tgz; ontoindex --version` |
+| Linux/macOS        | `npm install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.1/ontoindex-2.2.1.tgz && ontoindex --version`   |
+| Windows PowerShell | `npm.cmd install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.1/ontoindex-2.2.1.tgz; ontoindex --version` |
 
 ## First Run
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ OpenCode example:
 | Check blast radius     | `ontoindex impact validateUser --include-tests --depth 2` | `ontoindex impact validateUser --include-tests --depth 2` |
 | Review current diff    | `ontoindex review diff`                                   | `ontoindex review diff`                                   |
 | Audit before commit    | `ontoindex detect-changes`                                | `ontoindex detect-changes`                                |
+| Verify audit chain     | `ontoindex audit integrity --json`                        | `ontoindex audit integrity --json`                        |
 | Rebuild from scratch   | `ontoindex analyze --force`                               | `ontoindex analyze --force`                               |
 
 Core MCP surfaces include:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The default path is local: install, analyze, setup, connect MCP, serve, and gene
 [![License: AGPL-3.0-or-later](https://img.shields.io/badge/License-AGPL--3.0--or--later-blue.svg)](https://www.gnu.org/licenses/agpl-3.0.html)
 [![GitHub](https://img.shields.io/badge/GitHub-ontograph%2Fontoindex-181717?logo=github)](https://github.com/ontograph/ontoindex)
 
-- Current release: `2.1.4`
+- Current GitHub release: `2.2.0`
 - Source repository: [github.com/ontograph/ontoindex](https://github.com/ontograph/ontoindex)
 - Security policy: [SECURITY.md](SECURITY.md)
 - Enterprise contact: [erasyuk@gmail.com](mailto:erasyuk@gmail.com)
@@ -128,32 +128,29 @@ if (Test-Path "$env:APPDATA\npm\ontoindex.ps1") { Remove-Item "$env:APPDATA\npm\
 
 Installer configuration:
 
-| Purpose                        | Linux/macOS                                                                    | Windows PowerShell                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| Use another release repository | `ONTOINDEX_GITHUB_REPO=owner/repo ./scripts/install-ontoindex-latest.sh`       | `$env:ONTOINDEX_GITHUB_REPO='owner/repo'; .\scripts\install-ontoindex-latest.ps1`      |
-| Use a local downloaded tarball | `ONTOINDEX_LOCAL_ASSET="$PWD/ontoindex-2.1.4.tgz" ./scripts/install-ontoindex-latest.sh` | — |
-| Use a user npm prefix          | `ONTOINDEX_NPM_PREFIX="$HOME/.local" ./scripts/install-ontoindex-latest.sh`    | `$env:ONTOINDEX_NPM_PREFIX="$env:APPDATA\npm"; .\scripts\install-ontoindex-latest.ps1` |
-| Force user prefix              | `ONTOINDEX_NPM_PREFIX="$HOME/.local" ./scripts/install-ontoindex-latest.sh`    | `.\scripts\install-ontoindex-latest.ps1 -ForceUserPrefix`                              |
-| Require FTS/vector cache prefetch | `ONTOINDEX_REQUIRE_LADYBUG_EXTENSIONS=1 ./scripts/install-ontoindex-latest.sh` | `$env:ONTOINDEX_REQUIRE_LADYBUG_EXTENSIONS='1'; .\scripts\install-ontoindex-latest.ps1` |
-| Skip FTS/vector cache prefetch    | `ONTOINDEX_SKIP_LADYBUG_EXTENSIONS=1 ./scripts/install-ontoindex-latest.sh`    | `$env:ONTOINDEX_SKIP_LADYBUG_EXTENSIONS='1'; .\scripts\install-ontoindex-latest.ps1`    |
+| Purpose                           | Linux/macOS                                                                              | Windows PowerShell                                                                      |
+| --------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Use another release repository    | `ONTOINDEX_GITHUB_REPO=owner/repo ./scripts/install-ontoindex-latest.sh`                 | `$env:ONTOINDEX_GITHUB_REPO='owner/repo'; .\scripts\install-ontoindex-latest.ps1`       |
+| Use a local downloaded tarball    | `ONTOINDEX_LOCAL_ASSET="$PWD/ontoindex-2.2.0.tgz" ./scripts/install-ontoindex-latest.sh` | —                                                                                       |
+| Use a user npm prefix             | `ONTOINDEX_NPM_PREFIX="$HOME/.local" ./scripts/install-ontoindex-latest.sh`              | `$env:ONTOINDEX_NPM_PREFIX="$env:APPDATA\npm"; .\scripts\install-ontoindex-latest.ps1`  |
+| Force user prefix                 | `ONTOINDEX_NPM_PREFIX="$HOME/.local" ./scripts/install-ontoindex-latest.sh`              | `.\scripts\install-ontoindex-latest.ps1 -ForceUserPrefix`                               |
+| Require FTS/vector cache prefetch | `ONTOINDEX_REQUIRE_LADYBUG_EXTENSIONS=1 ./scripts/install-ontoindex-latest.sh`           | `$env:ONTOINDEX_REQUIRE_LADYBUG_EXTENSIONS='1'; .\scripts\install-ontoindex-latest.ps1` |
+| Skip FTS/vector cache prefetch    | `ONTOINDEX_SKIP_LADYBUG_EXTENSIONS=1 ./scripts/install-ontoindex-latest.sh`              | `$env:ONTOINDEX_SKIP_LADYBUG_EXTENSIONS='1'; .\scripts\install-ontoindex-latest.ps1`    |
 
-### Install with npm
+### npm Registry Status
 
-Use this path when npm publication is available in your environment.
-
-| Platform           | Command                                                    |
-| ------------------ | ---------------------------------------------------------- |
-| Linux/macOS        | `npm install -g ontoindex@2.1.4 && ontoindex --version`   |
-| Windows PowerShell | `npm.cmd install -g ontoindex@2.1.4; ontoindex --version` |
+OntoIndex 2.2.0 is distributed as a GitHub release tarball. It is not published
+to the public npm registry; install it with the GitHub installer or immutable
+tarball URL below.
 
 ### Install from a Release Tarball URL
 
 Use this when you want an immutable GitHub release asset.
 
-| Platform           | Command                                                                                                                         |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| Linux/macOS        | `npm install -g https://github.com/ontograph/ontoindex/releases/download/v2.1.4/ontoindex-2.1.4.tgz && ontoindex --version`   |
-| Windows PowerShell | `npm.cmd install -g https://github.com/ontograph/ontoindex/releases/download/v2.1.4/ontoindex-2.1.4.tgz; ontoindex --version` |
+| Platform           | Command                                                                                                                                       |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Linux/macOS        | `npm install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.0/ontoindex-2.2.0.tgz && ontoindex --version`   |
+| Windows PowerShell | `npm.cmd install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.0/ontoindex-2.2.0.tgz; ontoindex --version` |
 
 ## First Run
 
@@ -251,6 +248,25 @@ OpenCode example:
   }
 }
 ```
+
+### Managed Freshness Recovery
+
+Use `gn_ensure_fresh` as the prerequisite and submission surface. It reports
+freshness and capability requirements, then returns an `analysisSubmission`
+status of `not-requested`, `not-needed`, `blocked`, `queued`, `reused`, or
+`failed`. Submission and reuse are bound to the repository, target commit,
+source manifest, requested capabilities, and analysis options.
+
+When a job ID is returned, observe it with `gn_analyze_job`. A running job
+returns `REFRESH_RUNNING`. Terminal success is reported as `REFRESHED` only
+after OntoIndex validates the job-bound publication receipt, confirms that the
+receipt generation is active, and repeats the original capability-aware
+freshness check. Execution failure returns `FAILED`; missing publication or
+postcondition proof returns `FRESHNESS_UNCONFIRMED`.
+
+Clients must not delete `.ontoindex/analyze.lock`. The analyzer owns lock
+acquisition, dead-owner reclamation, and owner-safe release. Retry the original
+graph request unchanged only after `REFRESHED`.
 
 ## Common Agent Workflows
 
@@ -354,10 +370,10 @@ The browser-only mode can inspect uploaded ZIPs in memory. For larger repositori
 
 Images:
 
-| Image                                    | Purpose                                        |
-| ---------------------------------------- | ---------------------------------------------- |
-| `ghcr.io/ontograph/ontoindex:2.1.4`     | CLI, MCP server, and `ontoindex serve` backend |
-| `ghcr.io/ontograph/ontoindex-web:2.1.4` | Web UI                                         |
+| Image                                   | Purpose                                             |
+| --------------------------------------- | --------------------------------------------------- |
+| `ghcr.io/ontograph/ontoindex:2.1.4`     | Latest published CLI, MCP server, and backend image |
+| `ghcr.io/ontograph/ontoindex-web:2.1.4` | Latest published web UI image                       |
 
 ## Comparison With Related Tools
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Use this when you want an immutable GitHub release asset.
 
 | Platform           | Command                                                                                                                                       |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Linux/macOS        | `npm install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.0/ontoindex-2.2.0.tgz && ontoindex --version`   |
-| Windows PowerShell | `npm.cmd install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.0/ontoindex-2.2.0.tgz; ontoindex --version` |
+| Linux/macOS        | `npm install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.0-r1/ontoindex-2.2.0.tgz && ontoindex --version`   |
+| Windows PowerShell | `npm.cmd install -g https://github.com/ontograph/ontoindex/releases/download/github-release%2F2.2.0-r1/ontoindex-2.2.0.tgz; ontoindex --version` |
 
 ## First Run
 
@@ -372,8 +372,8 @@ Images:
 
 | Image                                   | Purpose                                             |
 | --------------------------------------- | --------------------------------------------------- |
-| `ghcr.io/ontograph/ontoindex:2.1.4`     | Latest published CLI, MCP server, and backend image |
-| `ghcr.io/ontograph/ontoindex-web:2.1.4` | Latest published web UI image                       |
+| `ghcr.io/ontograph/ontoindex:2.2.0`     | Latest published CLI, MCP server, and backend image |
+| `ghcr.io/ontograph/ontoindex-web:2.2.0` | Latest published web UI image                       |
 
 ## Comparison With Related Tools
 

--- a/RELEASE_READINESS_V2.2.0.md
+++ b/RELEASE_READINESS_V2.2.0.md
@@ -1,0 +1,87 @@
+# OntoIndex 2.2.0 Release Readiness
+
+Status: **READY FOR RELEASE**
+
+Prepared: 2026-08-18
+Target package version: `2.2.0`
+Distribution tag: `github-release/2.2.0`
+
+## Selected Scope
+
+This minor release combines tamper-evident audit event integrity with the
+managed-analysis freshness recovery contract. The release includes exact job
+reuse identity, job-bound publication receipts, capability-aware terminal
+post-checks, missing-embedding recovery, structured submission and lock
+conflicts, and transactional generation publication and rollback.
+
+`STALLED` worker replacement remains deferred. Heartbeats, renewable leases,
+attempt epochs, replacement authority, and stale-worker publication fencing
+require a separate ADR before they can become a supported lifecycle state.
+
+## Distribution Safety
+
+- Do not create or push a stable `v*` tag. `.github/workflows/publish.yml`
+  publishes matching stable tags to npm.
+- Do not dispatch the release-candidate workflow; it publishes npm RC packages
+  and container images.
+- Build and verify `ontoindex-2.2.0.tgz` locally.
+- Push the release commit to `feat/audit-event-integrity`.
+- Create the GitHub release from `github-release/2.2.0` and attach the verified
+  tarball. This tag does not match the npm publish workflow.
+
+## Required Gates
+
+- TypeScript type-check.
+- Focused managed-analysis and publication tests.
+- Complete unit and integration suites.
+- Root Prettier and ESLint.
+- `ontoindex-shared` build.
+- `ontoindex` production build.
+- `npm publish --dry-run` only; never run a real npm publish.
+- `npm pack` and tarball structure/version/bin verification.
+- Built CLI smoke test.
+- `git diff --check`, scope review, and clean release commit.
+- Exactly one clean-commit reindex followed by `gn_diagnose`,
+  `gn_pre_commit_audit`, and `gn_verify_diff`.
+
+## Validation Results
+
+Completed on 2026-08-18:
+
+- TypeScript type-check passed with `npx tsc --noEmit --pretty false`.
+- Focused managed-analysis matrix passed: 8 files, 223 tests.
+- Complete unit suite passed: 456 files, 6,983 tests; 64 tests skipped.
+- Complete integration suite passed: 83 files, 2,606 tests; 4 files and
+  244 tests skipped by their existing environment/fixture conditions.
+- Prettier check passed.
+- ESLint passed with 0 errors; 4,706 pre-existing warnings remain advisory.
+- `ontoindex-shared` and `ontoindex` production builds passed.
+- `git diff --check` passed.
+- `npm publish --dry-run` passed without publishing: 29.6 MB compressed,
+  379.4 MB unpacked, 2,006 files.
+- `npm pack --pack-destination ..` produced `ontoindex-2.2.0.tgz` with
+  SHA-256
+  `4d2cbb3a0a82c2a55da7eb0059ace8bc3e9eada935ea38c98023b47b424192cc`.
+- Tarball verification passed for package version `2.2.0`, bin mapping
+  `ontoindex -> dist/cli/index.js`, and `package/dist/cli/index.js` presence.
+- A normal isolated consumer install of the tarball passed; the packaged CLI
+  reported `2.2.0` and completed `ontoindex --help`.
+
+Installing with `--ignore-scripts` is not a supported smoke path because it
+prevents `@ladybugdb/core` from installing its native binary. The normal npm
+installation path was tested and passed.
+
+The remaining release gates are the clean release commit, exactly one
+post-commit reindex, graph-aware post-commit verification, branch/tag push,
+GitHub release creation, and public-asset verification.
+
+## Release Sequence
+
+1. Complete all validation and record results in this file.
+2. Commit as `release: v2.2.0`.
+3. Reindex the clean commit exactly once.
+4. Review the post-commit graph gates.
+5. Push the feature branch.
+6. Create and push annotated tag `github-release/2.2.0`.
+7. Create the GitHub release and attach `ontoindex-2.2.0.tgz`.
+8. Verify the public asset can be downloaded and reports version `2.2.0`.

--- a/ontoindex/CHANGELOG.md
+++ b/ontoindex/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to OntoIndex will be documented in this file.
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-18
+
+### Added
+
+- Added tamper-evident audit event chains and the read-only `ontoindex audit integrity` verification command, with an explicitly acknowledged archive-and-reset recovery path.
+- Added job-bound managed-analysis publication receipts covering repository identity, target HEAD, source manifest, requested capabilities, generation identity, analyzer contract, and publication time.
+- Added capability-aware terminal recovery results to `gn_analyze_job`: `REFRESH_RUNNING`, `REFRESHED`, `FAILED`, and `FRESHNESS_UNCONFIRMED`.
+
+### Changed
+
+- Split managed freshness recovery responsibilities: `gn_ensure_fresh` owns prerequisite classification and exact job submission or reuse, while `gn_analyze_job` owns receipt validation and the final capability-aware post-check.
+- Made managed job reuse identity include the target commit, source snapshot, requested graph and embedding capabilities, and analysis options.
+- Serialized generation activation, publication commit, and rollback under one owner-checked generation-pointer lock.
+- Made legacy audit stores read-only and made trust-sensitive dispatch fail closed unless the complete retained integrity chain verifies.
+
+### Fixed
+
+- Prevented exit code zero or a copied active generation ID from being treated as proof that a managed job published the requested graph.
+- Made missing required embeddings actionable even when the indexed commit already matches HEAD.
+- Prevented same-HEAD job reuse when the source manifest or requested capabilities differ.
+- Made active-job conflicts, analyzer-lock conflicts, and pre-job submission failures return structured outcomes without asking clients to delete analyzer locks.
+- Made generation publication transactional: failed coordinator commits restore the exact previous generation, first-generation failures remove the active pointer, concurrent activation is fenced, and failed generations remain available for diagnostics.
+- Surfaced owner-lock cleanup failures and rejected rollback through substituted generation symlinks.
+- Closed audit-store downgrade and laundering paths that could otherwise hide or re-sign tampered history.
+
 ## [2.1.5] - 2026-08-06
 
 ### Added

--- a/ontoindex/README.md
+++ b/ontoindex/README.md
@@ -150,6 +150,23 @@ Your AI agent gets these tools automatically:
 
 > With one indexed repo, the `repo` param is optional. With multiple, specify which: `query({query: "auth", repo: "my-app"})`.
 
+### Managed Freshness Recovery
+
+`gn_ensure_fresh` is the prerequisite and managed-submission surface. With
+`autoAnalyze: true`, it returns a structured submission status and either
+queues or reuses work only when repository, target commit, source manifest,
+requested graph or embedding capabilities, and analysis options match.
+
+Observe a returned job ID with `gn_analyze_job`. Its recovery disposition is
+`REFRESH_RUNNING`, `REFRESHED`, `FAILED`, or `FRESHNESS_UNCONFIRMED`.
+`REFRESHED` requires a job-bound publication receipt, the matching active
+generation, and a final freshness check using the original capability
+requirements. Exit code zero or job completion alone is not success proof.
+
+Analysis locks are analyzer-owned. MCP clients and agents must never remove
+`.ontoindex/analyze.lock`; retry the triggering graph operation unchanged only
+after the terminal result is `REFRESHED`.
+
 When MCP starts from a tool checkout, it uses `ONTOINDEX_MCP_PROJECT_CWD` (set by `setup`) as the target-project hint, and startup checks this against the selected repo target.
 If the selected repo target does not match that project scope, startup fails loudly unless override is enabled.
 For external helper checkouts (for example, `cwd=/opt/demodb/_workfolder/OntoIndex` while the target repo is `/opt/demodb/_workfolder/ontocode`), set setup and config against the target repo path:

--- a/ontoindex/fixtures/mcp-tool-contract/stable-tools.snapshot.json
+++ b/ontoindex/fixtures/mcp-tool-contract/stable-tools.snapshot.json
@@ -404,6 +404,15 @@
             "description": "Also check and populate embeddings. Default: false.",
             "default": false
           },
+          "requiredGraphCapabilities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["symbols", "impact", "processes"]
+            },
+            "description": "Required graph capabilities for freshness and managed analysis. Values are deduplicated and normalized; default: [\"symbols\"].",
+            "default": ["symbols"]
+          },
           "autoAnalyze": {
             "type": "boolean",
             "description": "Submit a durable ontoindex analyze job when refresh is required. Default: false.",
@@ -437,7 +446,7 @@
     {
       "name": "gn_analyze_job",
       "kind": "super",
-      "description": "Observe or cancel a durable repository analysis job previously returned by gn_ensure_fresh(autoAnalyze=true).",
+      "description": "Observe or cancel a durable repository analysis job previously returned by gn_ensure_fresh(autoAnalyze=true). Successful recovery requires exact commit source identity, a matching publication receipt, and a clean committed-HEAD post-check.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/ontoindex/package-lock.json
+++ b/ontoindex/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ontoindex",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ontoindex",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/ontoindex/package-lock.json
+++ b/ontoindex/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ontoindex",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ontoindex",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/ontoindex/package.json
+++ b/ontoindex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontoindex",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "AGPL-3.0-or-later",

--- a/ontoindex/package.json
+++ b/ontoindex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontoindex",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "AGPL-3.0-or-later",

--- a/ontoindex/src/cli/analyze.ts
+++ b/ontoindex/src/cli/analyze.ts
@@ -38,6 +38,7 @@ import {
 } from '../core/indexing/file-scope-preview.js';
 import type { PipelineProfile } from '../core/ingestion/pipeline.js';
 import type { EmbeddingLifecycleSummary } from '../core/run-analyze.js';
+import { parseManagedAnalysisContextFromEnv } from '../core/analysis/analysis-publication-receipt.js';
 
 const HEAP_MB = 8192;
 const HEAP_FLAG = `--max-old-space-size=${HEAP_MB}`;
@@ -446,6 +447,7 @@ function formatFileScopeExplanation(
 }
 
 export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOptions) => {
+  const managedAnalysis = parseManagedAnalysisContextFromEnv();
   if (ensureHeap()) return;
   if (options?.allowDuplicateName) {
     throw new Error('--allow-duplicate-name is no longer supported. Use --name <unique-alias>.');
@@ -648,7 +650,11 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
       {
         // Pipeline re-index — OR'd with --skills because skill generation
         // needs a fresh pipelineResult.
-        force: options?.force || options?.skills || experimentalFileDeltaPlan?.forceFullAnalyze,
+        force:
+          managedAnalysis !== undefined ||
+          options?.force ||
+          options?.skills ||
+          experimentalFileDeltaPlan?.forceFullAnalyze,
         embeddings: options?.embeddings,
         annNeighbors: options?.annNeighbors,
         skipGit: options?.skipGit,
@@ -659,6 +665,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
         noStats: experimentalFileDeltaPlan?.safeToBound ? true : options?.noStats,
         skipNativeClose: process.env.ONTOINDEX_ANALYZE_NATIVE_CLOSE !== '1',
         registryName: options?.name,
+        ...(managedAnalysis ? { managedAnalysis } : {}),
       },
       {
         onProgress: (_phase, percent, message) => {

--- a/ontoindex/src/cli/audit.ts
+++ b/ontoindex/src/cli/audit.ts
@@ -12,7 +12,15 @@ import { getGitRoot, isGitRepo, getCurrentCommit } from '../storage/git.js';
 import { getStoragePaths, loadMeta } from '../storage/repo-manager.js';
 import { initLbug, closeLbug } from '../core/lbug/pool-adapter.js';
 import { runAuditReport, formatAuditReport } from '../mcp/local/backend-audit-report.js';
-import { ingestAuditFindings, type AuditLintFinding } from '../core/audit-lifecycle/index.js';
+import {
+  getAuditEventStorePath,
+  inspectAuditEventStoreRaw,
+  ingestAuditFindings,
+  loadAuditEventStoreState,
+  recoverAuditEventStore,
+  getAuditProjectionPath,
+  type AuditLintFinding,
+} from '../core/audit-lifecycle/index.js';
 import { runAuditIngest } from '../mcp/super/audit-ingest.js';
 import { loadLifecycleFindings, runAuditVerify } from '../mcp/super/audit-verify.js';
 import { loadAuditBundles, runAuditLint } from '../mcp/super/audit-lint.js';
@@ -51,6 +59,13 @@ interface AuditLifecycleCommandOptions {
   maxIssues?: string | number;
   maxBundles?: string | number;
   persist?: boolean;
+}
+
+interface AuditIntegrityCommandOptions {
+  repo?: string;
+  json?: boolean;
+  resetBroken?: boolean;
+  acknowledgeDataLoss?: boolean;
 }
 
 function caughtMessage(err: unknown): unknown {
@@ -254,6 +269,117 @@ export const auditBundleCommand = async (options: AuditLifecycleCommandOptions =
   );
 };
 
+export const auditIntegrityCommand = async (options: AuditIntegrityCommandOptions = {}) => {
+  const repoPath = resolveLifecycleRepoPath(options);
+  const resetRequested = options.resetBroken === true;
+  const acknowledged = options.acknowledgeDataLoss === true;
+  const raw = await inspectAuditEventStoreRaw(getAuditEventStorePath(repoPath));
+
+  if (!raw.exists) {
+    const error =
+      resetRequested !== acknowledged
+        ? 'Both --reset-broken and --acknowledge-data-loss are required for reset.'
+        : resetRequested
+          ? 'Audit event store is absent; refusing reset and creating nothing.'
+          : undefined;
+    emitAuditIntegrity(
+      { status: 'VALID', exists: false, ...(error ? { error } : {}) },
+      options.json,
+    );
+    if (error) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  let status:
+    | { status: 'MALFORMED'; reason: string }
+    | {
+        status: 'VALID' | 'VALID_WITH_LEGACY_PREFIX' | 'LEGACY_UNVERIFIED' | 'BROKEN';
+        firstBrokenSequence?: number;
+        reason?: string;
+      };
+  if (raw.parseError) {
+    status = { status: 'MALFORMED', reason: raw.parseError };
+  } else {
+    try {
+      const state = await loadAuditEventStoreState(getAuditEventStorePath(repoPath));
+      status = {
+        status: state.integrity?.status ?? 'BROKEN',
+        ...(state.integrity?.firstBrokenSequence !== undefined
+          ? { firstBrokenSequence: state.integrity.firstBrokenSequence }
+          : {}),
+        ...(state.integrity?.reason !== undefined ? { reason: state.integrity.reason } : {}),
+      };
+    } catch (error: unknown) {
+      status = { status: 'MALFORMED', reason: String(caughtMessage(error) ?? error) };
+    }
+  }
+
+  if (resetRequested !== acknowledged) {
+    emitAuditIntegrity(
+      {
+        ...status,
+        exists: true,
+        error: 'Both --reset-broken and --acknowledge-data-loss are required for reset.',
+      },
+      options.json,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!resetRequested) {
+    emitAuditIntegrity({ ...status, exists: true }, options.json);
+    if (status.status === 'BROKEN' || status.status === 'MALFORMED') process.exitCode = 1;
+    return;
+  }
+
+  if (
+    status.status !== 'BROKEN' &&
+    status.status !== 'MALFORMED' &&
+    status.status !== 'LEGACY_UNVERIFIED'
+  ) {
+    emitAuditIntegrity(
+      {
+        ...status,
+        exists: true,
+        error: `Reset is only accepted for BROKEN, MALFORMED, or LEGACY_UNVERIFIED stores; observed ${status.status}.`,
+      },
+      options.json,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const recovery = await recoverAuditEventStore(
+      getAuditEventStorePath(repoPath),
+      getAuditProjectionPath(repoPath),
+    );
+    emitAuditIntegrity(
+      {
+        ...status,
+        exists: true,
+        archivePath: recovery.archivePath,
+        archiveSha256: recovery.archiveSha256,
+        archiveBytes: recovery.archiveBytes,
+        statePath: recovery.statePath,
+        projectionPath: recovery.projectionPath,
+        message:
+          'Store history was archived and reset; re-ingest audit events. The archive was retained.',
+      },
+      options.json,
+    );
+  } catch (error: unknown) {
+    emitAuditIntegrity(
+      { ...status, exists: true, error: caughtMessage(error) ?? 'Audit event store reset failed.' },
+      options.json,
+    );
+    process.exitCode = 1;
+  }
+};
+
 function resolveLifecycleRepoPath(options: AuditLifecycleCommandOptions): string {
   if (options.repo) return path.resolve(options.repo);
   const gitRoot = getGitRoot(process.cwd());
@@ -261,6 +387,23 @@ function resolveLifecycleRepoPath(options: AuditLifecycleCommandOptions): string
     throw new Error('Not inside a git repository and no --repo specified.');
   }
   return gitRoot;
+}
+
+function emitAuditIntegrity(payload: Record<string, unknown>, json = false): void {
+  if (json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  const status = String(payload.status);
+  const exists = payload.exists === true;
+  console.log(`Audit event store: ${status} (${exists ? 'present' : 'absent'})`);
+  if (payload.firstBrokenSequence !== undefined || payload.reason !== undefined) {
+    console.log(
+      `Integrity failure: sequence ${payload.firstBrokenSequence ?? 'unknown'}; ${payload.reason ?? 'unknown reason'}`,
+    );
+  }
+  if (typeof payload.message === 'string') console.log(payload.message);
+  if (typeof payload.error === 'string') console.error(payload.error);
 }
 
 async function emitLifecycleReport(

--- a/ontoindex/src/cli/index.ts
+++ b/ontoindex/src/cli/index.ts
@@ -272,6 +272,15 @@ auditProgram
   .option('--no-persist', 'Do not write bundle events')
   .action(createLazyAction(() => import('./audit.js'), 'auditBundleCommand'));
 
+auditProgram
+  .command('integrity')
+  .description('Inspect or recover the audit event store integrity chain')
+  .option('--repo <path>', 'Repository path (defaults to current git root)')
+  .option('--json', 'Emit JSON')
+  .option('--reset-broken', 'Archive and replace a broken or malformed store')
+  .option('--acknowledge-data-loss', 'Acknowledge that reset discards the active event history')
+  .action(createLazyAction(() => import('./audit.js'), 'auditIntegrityCommand'));
+
 program
   .command('augment <pattern>')
   .description('Augment a search pattern with knowledge graph context (used by hooks)')

--- a/ontoindex/src/core/analysis/analysis-coordinator.ts
+++ b/ontoindex/src/core/analysis/analysis-coordinator.ts
@@ -9,6 +9,7 @@ import { readAnalyzeLock } from '../runtime/runtime-health.js';
 import {
   ANALYSIS_REQUESTED_CAPABILITIES_VERSION,
   assertValidManagedAnalysisContext,
+  isValidSourceIdentity,
   type AnalysisRequestedCapabilities,
   type ManagedAnalysisContext,
 } from './analysis-publication-receipt.js';
@@ -172,8 +173,8 @@ export async function submitAnalysisJob(
   };
   validateRequestedCapabilities(requestedCapabilities);
   validateTargetHead(input.targetHead);
-  validateSourceIdentity(input.sourceIdentity, input.targetHead);
   validateSha256(input.sourceManifestDigest, 'Analysis source manifest digest');
+  validateSourceIdentity(input.sourceIdentity, input.targetHead, input.sourceManifestDigest);
 
   const optionsDigest = digest(
     stableJson({
@@ -1184,9 +1185,12 @@ function validateTargetHead(targetHead: unknown): asserts targetHead is string {
 function validateSourceIdentity(
   sourceIdentity: unknown,
   targetHead: string,
+  sourceManifestDigest: string,
 ): asserts sourceIdentity is string {
-  if (typeof sourceIdentity !== 'string' || sourceIdentity !== `commit:${targetHead}`) {
-    throw new Error('Analysis source identity must match the requested target HEAD.');
+  if (!isValidSourceIdentity(sourceIdentity, targetHead, sourceManifestDigest)) {
+    throw new Error(
+      'Analysis source identity must match the requested target HEAD or the analyzed source manifest.',
+    );
   }
 }
 

--- a/ontoindex/src/core/analysis/analysis-coordinator.ts
+++ b/ontoindex/src/core/analysis/analysis-coordinator.ts
@@ -4,10 +4,21 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { loadMeta } from '../../storage/repo-manager.js';
+import { getStoragePaths } from '../../storage/repo-manager.js';
+import { readAnalyzeLock } from '../runtime/runtime-health.js';
+import {
+  ANALYSIS_REQUESTED_CAPABILITIES_VERSION,
+  assertValidManagedAnalysisContext,
+  type AnalysisRequestedCapabilities,
+  type ManagedAnalysisContext,
+} from './analysis-publication-receipt.js';
 
 export type AnalysisJobStatus = 'queued' | 'running' | 'complete' | 'failed' | 'cancelled';
+export type AnalysisJobPublicationState = 'publishing' | 'published';
 const JOB_TTL_MS = 60 * 60 * 1000;
+const RUNNER_LAUNCH_TIMEOUT_MS = 30_000;
+const ACTIVE_MUTATION_LOCK_MAX_ATTEMPTS = 500;
+const ACTIVE_MUTATION_LOCK_RETRY_DELAY_MS = 10;
 
 export interface AnalysisJobRecord {
   version: 1;
@@ -15,19 +26,25 @@ export interface AnalysisJobRecord {
   status: AnalysisJobStatus;
   repoPath: string;
   targetHead: string;
-  sourceManifestDigest?: string;
+  requestedCapabilities: AnalysisRequestedCapabilities;
+  sourceIdentity: string;
+  sourceManifestDigest: string;
   optionsDigest: string;
   command: string;
   args: string[];
   logPath: string;
   createdAt: string;
+  launchDeadlineAt?: string;
   startedAt?: string;
   completedAt?: string;
   runnerPid?: number;
   runnerProcessStartIdentity?: string;
+  analyzerPid?: number;
+  analyzerProcessStartIdentity?: string;
   exitCode?: number | null;
   signal?: NodeJS.Signals | null;
   generationId?: string;
+  publicationState?: AnalysisJobPublicationState;
   error?: string;
 }
 
@@ -37,7 +54,103 @@ export interface SubmitAnalysisJobInput {
   command: string;
   args: string[];
   options: Record<string, unknown>;
+  requestedCapabilities?: AnalysisRequestedCapabilities;
+  sourceIdentity: string;
+  sourceManifestDigest: string;
 }
+
+export class AnalysisJobLockConflictError extends Error {
+  readonly code = 'LOCK_CONFLICT';
+  readonly lockState: 'active' | 'unknown';
+  readonly lockReason?: string;
+
+  constructor(lockState: 'active' | 'unknown', lockReason?: string) {
+    super(lockReason ?? 'Analysis lock ownership could not be safely reconciled.');
+    this.name = 'AnalysisJobLockConflictError';
+    this.lockState = lockState;
+    this.lockReason = lockReason;
+  }
+}
+
+export class AnalysisJobActiveConflictError extends Error {
+  readonly code = 'ACTIVE_JOB_CONFLICT';
+  readonly activeJobId: string;
+
+  constructor(activeJobId: string) {
+    super(`Analysis job ${activeJobId} is already active for a different analysis request.`);
+    this.name = 'AnalysisJobActiveConflictError';
+    this.activeJobId = activeJobId;
+  }
+}
+
+export type AnalysisJobCancellationRefusalReason =
+  | 'JOB_NOT_FOUND'
+  | 'JOB_NOT_CANCELLABLE'
+  | 'PROCESS_IDENTITY_UNAVAILABLE'
+  | 'PROCESS_IDENTITY_MISMATCH'
+  | 'SIGNAL_FAILED';
+
+export interface AnalysisJobCancellationResult {
+  job: AnalysisJobRecord | null;
+  cancelled: boolean;
+  refusal?: {
+    reasonCode: AnalysisJobCancellationRefusalReason;
+    message: string;
+  };
+}
+
+export interface AnalysisJobRunnerOwner {
+  pid: number;
+  processStartIdentity?: string;
+}
+
+export class ManagedAnalysisFencedAttemptError extends Error {
+  readonly code = 'MANAGED_ANALYSIS_FENCED_ATTEMPT';
+
+  constructor(message = 'Managed analysis attempt was fenced by the canonical job owner.') {
+    super(message);
+    this.name = 'ManagedAnalysisFencedAttemptError';
+  }
+}
+
+interface ActiveMutationLockRecord {
+  version: 1;
+  token: string;
+  pid: number;
+  processStartIdentity: string;
+  acquiredAt: string;
+  repoPath: string;
+}
+
+interface ActiveJobSnapshot {
+  markerId: string;
+  job: AnalysisJobRecord | null;
+}
+
+export type AnalysisJobLifecycleUpdate = Partial<
+  Pick<
+    AnalysisJobRecord,
+    | 'status'
+    | 'startedAt'
+    | 'completedAt'
+    | 'runnerPid'
+    | 'runnerProcessStartIdentity'
+    | 'exitCode'
+    | 'signal'
+    | 'error'
+  >
+>;
+
+const ANALYSIS_JOB_LIFECYCLE_FIELDS = [
+  'status',
+  'startedAt',
+  'completedAt',
+  'runnerPid',
+  'runnerProcessStartIdentity',
+  'exitCode',
+  'signal',
+  'error',
+] as const satisfies readonly (keyof AnalysisJobLifecycleUpdate)[];
 
 export async function submitAnalysisJob(
   input: SubmitAnalysisJobInput,
@@ -50,64 +163,135 @@ export async function submitAnalysisJob(
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   await cleanupExpiredJobs(dir);
 
+  const requestedCapabilities = input.requestedCapabilities ?? {
+    version: ANALYSIS_REQUESTED_CAPABILITIES_VERSION,
+    graph: true,
+    graphCapabilities: ['symbols'],
+    embeddings: false,
+    embeddingModelHash: null,
+  };
+  validateRequestedCapabilities(requestedCapabilities);
+  validateTargetHead(input.targetHead);
+  validateSourceIdentity(input.sourceIdentity, input.targetHead);
+  validateSha256(input.sourceManifestDigest, 'Analysis source manifest digest');
+
   const optionsDigest = digest(
-    stableJson({ command: input.command, args: input.args, options: input.options }),
+    stableJson({
+      command: input.command,
+      args: input.args,
+      options: input.options,
+      requestedCapabilities,
+      sourceIdentity: input.sourceIdentity,
+      sourceManifestDigest: input.sourceManifestDigest,
+    }),
   );
 
-  const active = await readActiveJob(repoPath);
-  if (active && (await isActive(active))) {
-    if (active.targetHead === input.targetHead && active.optionsDigest === optionsDigest) {
-      return { job: active, reused: true };
+  const submission = await withActiveMutationLock(repoPath, async () => {
+    let active = await readActiveSnapshotLocked(repoPath);
+    if (active?.job) {
+      const expired = await expireQueuedLaunchLocked(repoPath, active.job);
+      if (expired) active = null;
     }
-    throw new Error(
-      `Analysis job ${active.id} is already active for a different analysis request.`,
-    );
-  }
-  if (active) await clearActive(repoPath, active.id);
-
-  const id = randomUUID();
-  const job: AnalysisJobRecord = {
-    version: 1,
-    id,
-    status: 'queued',
-    repoPath,
-    targetHead: input.targetHead,
-    optionsDigest,
-    command: input.command,
-    args: input.args,
-    logPath: path.join(dir, `${id}.log`),
-    createdAt: new Date().toISOString(),
-  };
-  await writeJob(job);
-
-  try {
-    await fs.writeFile(activePath(repoPath), id, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
-  } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-    const winner = await readActiveJob(repoPath);
-    if (winner && (await isActive(winner))) {
-      await fs.rm(jobPath(repoPath, id), { force: true });
-      if (winner.targetHead === input.targetHead && winner.optionsDigest === optionsDigest) {
-        return { job: winner, reused: true };
+    const activeIsLive = active?.job ? await isActive(active.job) : false;
+    if (active?.job && activeIsLive) {
+      if (
+        isCompatibleActiveRequest(
+          active.job,
+          input.targetHead,
+          optionsDigest,
+          requestedCapabilities,
+          input.sourceIdentity,
+          input.sourceManifestDigest,
+        )
+      ) {
+        return { job: active.job, reused: true };
       }
-      throw new Error(
-        `Analysis job ${winner.id} is already active for a different analysis request.`,
-      );
+      throw new AnalysisJobActiveConflictError(active.job.id);
     }
-    await clearActive(repoPath, winner?.id);
-    await fs.writeFile(activePath(repoPath), id, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
-  }
+    if (active) await clearActiveLocked(repoPath, active.markerId);
+    const analyzeLock = await readAnalyzeLock(getStoragePaths(repoPath).storagePath, []);
+    if (analyzeLock.state === 'active' || analyzeLock.state === 'unknown') {
+      throw new AnalysisJobLockConflictError(analyzeLock.state, analyzeLock.reason);
+    }
+
+    const id = randomUUID();
+    const job: AnalysisJobRecord = {
+      version: 1,
+      id,
+      status: 'queued',
+      repoPath,
+      targetHead: input.targetHead,
+      requestedCapabilities,
+      sourceIdentity: input.sourceIdentity,
+      sourceManifestDigest: input.sourceManifestDigest,
+      optionsDigest,
+      command: input.command,
+      args: input.args,
+      logPath: path.join(dir, `${id}.log`),
+      createdAt: new Date().toISOString(),
+      launchDeadlineAt: new Date(Date.now() + RUNNER_LAUNCH_TIMEOUT_MS).toISOString(),
+    };
+    await writeJob(job);
+    try {
+      await fs.writeFile(activePath(repoPath), id, {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+      });
+    } catch (error: unknown) {
+      await fs.rm(jobPath(repoPath, id), { force: true }).catch(() => {});
+      throw error;
+    }
+    return { job, reused: false };
+  });
+
+  if (submission.reused) return submission;
 
   const runnerPath =
     process.env.ONTOINDEX_ANALYSIS_JOB_RUNNER_PATH ??
     fileURLToPath(new URL('./analysis-job-runner.js', import.meta.url));
-  const child = spawn(process.execPath, [runnerPath, jobPath(repoPath, id)], {
-    cwd: repoPath,
-    detached: true,
-    stdio: 'ignore',
+  try {
+    const child = spawn(process.execPath, [runnerPath, jobPath(repoPath, submission.job.id)], {
+      cwd: repoPath,
+      detached: true,
+      stdio: 'ignore',
+    });
+    await new Promise<void>((resolve, reject) => {
+      child.once('spawn', resolve);
+      child.once('error', reject);
+    });
+    child.unref();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await failAnalysisJobLaunch(repoPath, submission.job.id, message);
+    throw error;
+  }
+  return submission;
+}
+
+export async function failAnalysisJobLaunch(
+  repoPath: string,
+  id: string,
+  error: string,
+): Promise<AnalysisJobRecord | null> {
+  const resolvedRepoPath = path.resolve(repoPath);
+  return withActiveMutationLock(resolvedRepoPath, async () => {
+    const active = await readActiveSnapshotLocked(resolvedRepoPath);
+    const job =
+      active?.markerId === id
+        ? active.job
+        : await readJobFile(jobPath(resolvedRepoPath, id)).catch(() => null);
+    if (!job || job.status !== 'queued' || hasRecordedOwner(job)) return job;
+    const failed: AnalysisJobRecord = {
+      ...job,
+      status: 'failed',
+      completedAt: new Date().toISOString(),
+      error: `Analysis runner launch failed: ${error}`,
+    };
+    await writeJob(failed);
+    await clearActiveLocked(resolvedRepoPath, id);
+    return failed;
   });
-  child.unref();
-  return { job, reused: false };
 }
 
 export async function getAnalysisJob(
@@ -130,68 +314,754 @@ export async function getAnalysisJob(
   }
 }
 
+export async function claimAnalysisJobRunner(jobFile: string): Promise<AnalysisJobRecord | null> {
+  const supplied = await readJobFile(jobFile).catch(() => null);
+  if (!supplied) return null;
+  const repoPath = path.resolve(supplied.repoPath);
+  if (path.resolve(jobFile) !== jobPath(repoPath, supplied.id)) return null;
+
+  return withActiveMutationLock(repoPath, async () => {
+    const active = await readActiveSnapshotLocked(repoPath);
+    if (
+      active?.markerId !== supplied.id ||
+      !active.job ||
+      active.job.id !== supplied.id ||
+      active.job.repoPath !== repoPath ||
+      active.job.status !== 'queued' ||
+      hasRecordedOwner(active.job) ||
+      active.job.startedAt !== undefined ||
+      active.job.completedAt !== undefined ||
+      active.job.exitCode !== undefined ||
+      active.job.signal !== undefined
+    ) {
+      return null;
+    }
+
+    const processStartIdentity = await readProcessStartIdentity(process.pid);
+    const claimed: AnalysisJobRecord = {
+      ...active.job,
+      status: 'running',
+      runnerPid: process.pid,
+      ...(processStartIdentity ? { runnerProcessStartIdentity: processStartIdentity } : {}),
+      startedAt: new Date().toISOString(),
+    };
+    await writeJob(claimed);
+    return claimed;
+  });
+}
+
+export async function claimManagedAnalysisAnalyzer(
+  repoPath: string,
+  context: ManagedAnalysisContext,
+): Promise<AnalysisJobRecord> {
+  assertValidManagedAnalysisContext(context);
+  const resolvedRepoPath = path.resolve(repoPath);
+  return withActiveMutationLock(resolvedRepoPath, async () => {
+    const job = await requireManagedAnalysisJobLocked(resolvedRepoPath, context);
+    if (!job.runnerPid || !(await isVerifiedRunnerOwner(job))) {
+      throw fencedAttempt('Managed analysis runner ownership is no longer compatible.');
+    }
+
+    const processStartIdentity = await readProcessStartIdentity(process.pid);
+    if (job.analyzerPid !== undefined || job.analyzerProcessStartIdentity !== undefined) {
+      if (
+        job.analyzerPid !== process.pid ||
+        job.analyzerProcessStartIdentity !== (processStartIdentity ?? undefined)
+      ) {
+        throw fencedAttempt('Managed analysis analyzer ownership is already claimed.');
+      }
+      return job;
+    }
+
+    const claimed: AnalysisJobRecord = {
+      ...job,
+      analyzerPid: process.pid,
+      ...(processStartIdentity ? { analyzerProcessStartIdentity: processStartIdentity } : {}),
+    };
+    await writeJob(claimed);
+    return claimed;
+  });
+}
+
+export async function beginManagedAnalysisPublication(
+  repoPath: string,
+  context: ManagedAnalysisContext,
+): Promise<AnalysisJobRecord> {
+  assertValidManagedAnalysisContext(context);
+  const resolvedRepoPath = path.resolve(repoPath);
+  return withActiveMutationLock(resolvedRepoPath, async () => {
+    const job = await requireManagedAnalysisJobLocked(resolvedRepoPath, context);
+    await requireCurrentAnalyzerOwner(job);
+    if (job.publicationState === 'published') return job;
+    const publishing: AnalysisJobRecord = { ...job, publicationState: 'publishing' };
+    await writeJob(publishing);
+    return publishing;
+  });
+}
+
+export async function commitManagedAnalysisPublication(
+  repoPath: string,
+  context: ManagedAnalysisContext,
+  generationId: string,
+  sourceManifestDigest: string,
+): Promise<AnalysisJobRecord> {
+  assertValidManagedAnalysisContext(context);
+  validateSafeIdentifier(generationId, 'Analysis generation id');
+  validateSha256(sourceManifestDigest, 'Analysis publication source manifest digest');
+  if (sourceManifestDigest.toLowerCase() !== context.sourceManifestDigest.toLowerCase()) {
+    throw fencedAttempt(
+      'Managed analysis publication source manifest does not match the submitted manifest.',
+    );
+  }
+  const resolvedRepoPath = path.resolve(repoPath);
+  return withActiveMutationLock(resolvedRepoPath, async () => {
+    const job = await requireManagedAnalysisJobLocked(resolvedRepoPath, context);
+    await requireCurrentAnalyzerOwner(job);
+    if (job.publicationState !== 'publishing') {
+      throw fencedAttempt('Managed analysis publication was not begun by the canonical analyzer.');
+    }
+    const published: AnalysisJobRecord = {
+      ...job,
+      publicationState: 'published',
+      generationId,
+      sourceManifestDigest,
+    };
+    await writeJob(published);
+    return published;
+  });
+}
+
 export async function cancelAnalysisJob(
   repoPath: string,
   id: string,
-): Promise<{ job: AnalysisJobRecord | null; cancelled: boolean }> {
-  const job = await getAnalysisJob(repoPath, id);
-  if (!job || !(await isActive(job)) || !job.runnerPid) return { job, cancelled: false };
-  try {
-    process.kill(job.runnerPid, 'SIGTERM');
-    return { job, cancelled: true };
-  } catch {
-    return { job: await getAnalysisJob(repoPath, id), cancelled: false };
-  }
+): Promise<AnalysisJobCancellationResult> {
+  const resolvedRepoPath = path.resolve(repoPath);
+  return withActiveMutationLock(resolvedRepoPath, async () => {
+    const job = await readJobFile(jobPath(resolvedRepoPath, id)).catch(() => null);
+    if (!job) {
+      return cancellationRefusal(
+        null,
+        'JOB_NOT_FOUND',
+        'The analysis job does not exist or is no longer available.',
+      );
+    }
+    if (isTerminal(job.status) || job.publicationState) {
+      return cancellationRefusal(
+        job,
+        'JOB_NOT_CANCELLABLE',
+        job.publicationState
+          ? 'The analysis job has begun generation publication and can no longer be cancelled.'
+          : 'The analysis job is already terminal.',
+      );
+    }
+    if (!job.runnerPid && !job.analyzerPid) {
+      const cancelled: AnalysisJobRecord = {
+        ...job,
+        status: 'cancelled',
+        completedAt: new Date().toISOString(),
+        error: 'Analysis cancelled before the runner claimed the job.',
+      };
+      await writeJob(cancelled);
+      await clearActiveLocked(resolvedRepoPath, id);
+      return { job: cancelled, cancelled: true };
+    }
+
+    const runnerTarget = await verifiedCancellationTarget(
+      job.runnerPid,
+      job.runnerProcessStartIdentity,
+    );
+    if (runnerTarget.verified && job.runnerPid) {
+      return signalCancellationTarget(job, job.runnerPid, false, 'runner');
+    }
+    const analyzerTarget = await verifiedCancellationTarget(
+      job.analyzerPid,
+      job.analyzerProcessStartIdentity,
+    );
+    if (analyzerTarget.verified && job.analyzerPid) {
+      return signalCancellationTarget(job, job.analyzerPid, true, 'analyzer');
+    }
+    const refusal = runnerTarget.reason ?? analyzerTarget.reason ?? 'PROCESS_IDENTITY_UNAVAILABLE';
+    return cancellationRefusal(
+      job,
+      refusal,
+      refusal === 'PROCESS_IDENTITY_MISMATCH'
+        ? 'Cancellation was refused because an owned PID now belongs to a different process.'
+        : 'Cancellation was refused because no active process start identity can be verified on this host.',
+    );
+  });
 }
 
 export async function completeAnalysisJob(
   jobFile: string,
-  update: Partial<AnalysisJobRecord>,
+  update: AnalysisJobLifecycleUpdate,
+  expectedRunner?: AnalysisJobRunnerOwner,
 ): Promise<AnalysisJobRecord> {
-  const current = JSON.parse(await fs.readFile(jobFile, 'utf8')) as AnalysisJobRecord;
-  const next = { ...current, ...update };
-  const meta =
-    next.status === 'complete' ? await loadMeta(path.join(next.repoPath, '.ontoindex')) : null;
-  if (meta?.generationId) next.generationId = meta.generationId;
-  await writeJob(next);
-  if (!(await isActive(next))) await clearActive(next.repoPath, next.id);
-  return next;
-}
+  const supplied = await readJobFile(jobFile);
+  const repoPath = path.resolve(supplied.repoPath);
+  if (path.resolve(jobFile) !== jobPath(repoPath, supplied.id)) {
+    throw fencedAttempt('Analysis completion did not target the canonical job file.');
+  }
 
-export async function writeAnalysisJob(job: AnalysisJobRecord): Promise<void> {
-  await writeJob(job);
+  return withActiveMutationLock(repoPath, async () => {
+    const current = await readJobFile(jobFile);
+    if (isTerminal(current.status)) return current;
+    if (expectedRunner) {
+      const active = await readActiveSnapshotLocked(repoPath);
+      if (
+        active?.markerId !== current.id ||
+        current.runnerPid !== expectedRunner.pid ||
+        current.runnerProcessStartIdentity !== expectedRunner.processStartIdentity
+      ) {
+        return current;
+      }
+    }
+
+    const lifecycleUpdate = Object.fromEntries(
+      ANALYSIS_JOB_LIFECYCLE_FIELDS.filter((field) => Object.hasOwn(update, field)).map((field) => [
+        field,
+        update[field],
+      ]),
+    ) as AnalysisJobLifecycleUpdate;
+    if (lifecycleUpdate.status === 'complete' && current.publicationState !== 'published') {
+      lifecycleUpdate.status = 'failed';
+      lifecycleUpdate.error =
+        lifecycleUpdate.error ??
+        'Analysis exited successfully without committing generation publication.';
+    }
+    if (lifecycleUpdate.status === 'cancelled' && current.publicationState) {
+      lifecycleUpdate.status = 'failed';
+      lifecycleUpdate.error =
+        lifecycleUpdate.error ??
+        'Analysis termination occurred after generation publication began.';
+    }
+    const next = { ...current, ...lifecycleUpdate };
+    await writeJob(next);
+    if (isTerminal(next.status) || !(await isActive(next))) {
+      await clearActiveLocked(repoPath, next.id);
+    }
+    return next;
+  });
 }
 
 async function isActive(job: AnalysisJobRecord): Promise<boolean> {
   if (job.status !== 'queued' && job.status !== 'running') return false;
-  if (!job.runnerPid) {
-    return job.status === 'queued' && Date.now() - Date.parse(job.createdAt) < 10_000;
+  if (job.status === 'queued') return !launchDeadlineExpired(job);
+  const owners = [
+    ownerTuple(job.runnerPid, job.runnerProcessStartIdentity),
+    ownerTuple(job.analyzerPid, job.analyzerProcessStartIdentity),
+  ].filter((owner): owner is AnalysisJobRunnerOwner => owner !== null);
+  if (owners.length === 0) return true;
+  const states = await Promise.all(
+    owners.map((owner) => processOwnerState(owner.pid, owner.processStartIdentity)),
+  );
+  return states.some((state) => state !== 'stale');
+}
+
+async function expireQueuedLaunchLocked(
+  repoPath: string,
+  job: AnalysisJobRecord,
+): Promise<AnalysisJobRecord | null> {
+  if (job.status !== 'queued' || hasRecordedOwner(job) || !launchDeadlineExpired(job)) return null;
+  const failed: AnalysisJobRecord = {
+    ...job,
+    status: 'failed',
+    completedAt: new Date().toISOString(),
+    error: 'Analysis runner did not claim the job before the launch deadline.',
+  };
+  await writeJob(failed);
+  await clearActiveLocked(repoPath, job.id);
+  return failed;
+}
+
+function launchDeadlineExpired(job: AnalysisJobRecord): boolean {
+  if (!job.launchDeadlineAt) return true;
+  const deadline = Date.parse(job.launchDeadlineAt);
+  return !Number.isFinite(deadline) || Date.now() >= deadline;
+}
+
+async function requireManagedAnalysisJobLocked(
+  repoPath: string,
+  context: ManagedAnalysisContext,
+): Promise<AnalysisJobRecord> {
+  const active = await readActiveSnapshotLocked(repoPath);
+  const job = active?.job;
+  if (
+    active?.markerId !== context.jobId ||
+    !job ||
+    job.id !== context.jobId ||
+    job.repoPath !== repoPath ||
+    job.status !== 'running' ||
+    job.targetHead !== context.targetHead ||
+    job.optionsDigest !== context.optionsDigest ||
+    job.sourceIdentity !== context.sourceIdentity ||
+    job.sourceManifestDigest !== context.sourceManifestDigest ||
+    !sameRequestedCapabilities(job.requestedCapabilities, context.requestedCapabilities)
+  ) {
+    throw fencedAttempt('Managed analysis context no longer matches the active running job.');
   }
+  return job;
+}
+
+function sameRequestedCapabilities(
+  left: AnalysisRequestedCapabilities | undefined,
+  right: AnalysisRequestedCapabilities,
+): boolean {
+  return stableJson(left) === stableJson(right);
+}
+
+async function isVerifiedRunnerOwner(job: AnalysisJobRecord): Promise<boolean> {
+  if (!job.runnerPid) return false;
+  const state = await processOwnerState(job.runnerPid, job.runnerProcessStartIdentity);
+  if (state === 'live') return true;
+  return state === 'unknown' && job.runnerPid === process.ppid && isPidReachable(job.runnerPid);
+}
+
+async function requireCurrentAnalyzerOwner(job: AnalysisJobRecord): Promise<void> {
+  if (!job.analyzerPid || job.analyzerPid !== process.pid) {
+    throw fencedAttempt(
+      'Managed analysis publication is not owned by the current analyzer process.',
+    );
+  }
+  if (!job.analyzerProcessStartIdentity) return;
+  const currentIdentity = await readProcessStartIdentity(process.pid);
+  if (!currentIdentity || currentIdentity !== job.analyzerProcessStartIdentity) {
+    throw fencedAttempt('Managed analysis analyzer process identity can no longer be verified.');
+  }
+}
+
+function isPidReachable(pid: number): boolean {
   try {
-    process.kill(job.runnerPid, 0);
-    if (!job.runnerProcessStartIdentity) return true;
-    const currentIdentity = await readProcessStartIdentity(job.runnerPid);
-    return currentIdentity === job.runnerProcessStartIdentity;
+    process.kill(pid, 0);
+    return true;
   } catch {
     return false;
   }
 }
 
-async function readActiveJob(repoPath: string): Promise<AnalysisJobRecord | null> {
+function hasRecordedOwner(job: AnalysisJobRecord): boolean {
+  return (
+    job.runnerPid !== undefined ||
+    job.runnerProcessStartIdentity !== undefined ||
+    job.analyzerPid !== undefined ||
+    job.analyzerProcessStartIdentity !== undefined
+  );
+}
+
+function ownerTuple(
+  pid: number | undefined,
+  processStartIdentity: string | undefined,
+): AnalysisJobRunnerOwner | null {
+  return pid === undefined ? null : { pid, processStartIdentity };
+}
+
+async function processOwnerState(
+  pid: number,
+  expectedIdentity: string | undefined,
+): Promise<'live' | 'stale' | 'unknown'> {
   try {
-    const id = (await fs.readFile(activePath(repoPath), 'utf8')).trim();
-    return id ? await getAnalysisJob(repoPath, id) : null;
+    process.kill(pid, 0);
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === 'EPERM') return 'unknown';
+    return 'stale';
+  }
+  if (!expectedIdentity) return 'unknown';
+  const currentIdentity = await readProcessStartIdentity(pid);
+  if (!currentIdentity) return 'unknown';
+  return currentIdentity === expectedIdentity ? 'live' : 'stale';
+}
+
+async function verifiedCancellationTarget(
+  pid: number | undefined,
+  expectedIdentity: string | undefined,
+): Promise<{
+  verified: boolean;
+  reason?: Extract<
+    AnalysisJobCancellationRefusalReason,
+    'PROCESS_IDENTITY_UNAVAILABLE' | 'PROCESS_IDENTITY_MISMATCH'
+  >;
+}> {
+  if (pid === undefined) return { verified: false };
+  if (!expectedIdentity) {
+    return { verified: false, reason: 'PROCESS_IDENTITY_UNAVAILABLE' };
+  }
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return { verified: false, reason: 'PROCESS_IDENTITY_UNAVAILABLE' };
+  }
+  const currentIdentity = await readProcessStartIdentity(pid);
+  if (!currentIdentity) {
+    return { verified: false, reason: 'PROCESS_IDENTITY_UNAVAILABLE' };
+  }
+  if (currentIdentity !== expectedIdentity) {
+    return { verified: false, reason: 'PROCESS_IDENTITY_MISMATCH' };
+  }
+  return { verified: true };
+}
+
+async function signalCancellationTarget(
+  job: AnalysisJobRecord,
+  pid: number,
+  signalProcessGroup: boolean,
+  ownerLabel: 'runner' | 'analyzer',
+): Promise<AnalysisJobCancellationResult> {
+  try {
+    process.kill(signalProcessGroup && process.platform !== 'win32' ? -pid : pid, 'SIGTERM');
+    return { job, cancelled: true };
+  } catch {
+    return cancellationRefusal(
+      job,
+      'SIGNAL_FAILED',
+      `The ${ownerLabel} identity was verified, but the cancellation signal could not be delivered.`,
+    );
+  }
+}
+
+function fencedAttempt(message: string): ManagedAnalysisFencedAttemptError {
+  return new ManagedAnalysisFencedAttemptError(message);
+}
+
+async function readJobFile(file: string): Promise<AnalysisJobRecord> {
+  return JSON.parse(await fs.readFile(file, 'utf8')) as AnalysisJobRecord;
+}
+
+async function readActiveSnapshotLocked(repoPath: string): Promise<ActiveJobSnapshot | null> {
+  const rawMarker = await fs.readFile(activePath(repoPath), 'utf8').catch((error: unknown) => {
+    if (isNodeError(error) && error.code === 'ENOENT') return null;
+    throw error;
+  });
+  if (rawMarker === null) return null;
+  const markerId = rawMarker.trim();
+  if (!/^[0-9a-f-]+$/i.test(markerId)) return { markerId, job: null };
+  const job = await fs
+    .readFile(jobPath(repoPath, markerId), 'utf8')
+    .then((value) => JSON.parse(value) as AnalysisJobRecord)
+    .catch(() => null);
+  return { markerId, job };
+}
+
+async function clearActiveLocked(repoPath: string, expectedId: string): Promise<void> {
+  const current = await fs.readFile(activePath(repoPath), 'utf8').catch((error: unknown) => {
+    if (isNodeError(error) && error.code === 'ENOENT') return null;
+    throw error;
+  });
+  if (current === null || current.trim() !== expectedId) return;
+  await fs.rm(activePath(repoPath), { force: true });
+}
+
+async function withActiveMutationLock<T>(repoPath: string, callback: () => Promise<T>): Promise<T> {
+  const lockPath = activeMutationLockPath(repoPath);
+  const token = randomUUID();
+  const processStartIdentity = await readProcessStartIdentity(process.pid);
+  await acquireActiveMutationLock(lockPath, repoPath, token, processStartIdentity);
+  try {
+    return await callback();
+  } finally {
+    await releaseActiveMutationLock(lockPath, token, processStartIdentity);
+  }
+}
+
+async function acquireActiveMutationLock(
+  lockPath: string,
+  repoPath: string,
+  token: string,
+  processStartIdentity: string | null,
+): Promise<void> {
+  const recoveryPath = `${lockPath}.recovery`;
+  await fs.mkdir(path.dirname(lockPath), { recursive: true, mode: 0o700 });
+  for (let attempt = 0; attempt < ACTIVE_MUTATION_LOCK_MAX_ATTEMPTS; attempt += 1) {
+    if (await hasActiveRecoveryClaim(recoveryPath)) {
+      if (attempt + 1 < ACTIVE_MUTATION_LOCK_MAX_ATTEMPTS) {
+        await delay(ACTIVE_MUTATION_LOCK_RETRY_DELAY_MS);
+        continue;
+      }
+      break;
+    }
+    const recovery = await readActiveMutationLock(recoveryPath);
+    if (recovery) {
+      const recoveryOwnerActive = await isActiveMutationLockOwnerActive(recovery);
+      if (recoveryOwnerActive === false) {
+        if (await reclaimStaleRecoveryOwner(recoveryPath, recovery, processStartIdentity)) {
+          continue;
+        }
+      } else if (recoveryOwnerActive === null) {
+        throw new Error(`Cannot safely validate analysis lock recovery owner: ${recoveryPath}`);
+      }
+      if (attempt + 1 < ACTIVE_MUTATION_LOCK_MAX_ATTEMPTS) {
+        await delay(ACTIVE_MUTATION_LOCK_RETRY_DELAY_MS);
+        continue;
+      }
+      break;
+    }
+    if (await pathExists(recoveryPath)) {
+      throw new Error(
+        `Cannot safely recover malformed analysis lock recovery owner: ${recoveryPath}`,
+      );
+    }
+    if (await hasActiveRecoveryClaim(recoveryPath)) continue;
+
+    try {
+      await createActiveMutationLock(lockPath, repoPath, token, processStartIdentity);
+      return;
+    } catch (error: unknown) {
+      if (!isNodeError(error) || error.code !== 'EEXIST') throw error;
+    }
+
+    const existing = await readActiveMutationLock(lockPath);
+    if (!existing) {
+      if (!(await pathExists(lockPath))) {
+        await delay(ACTIVE_MUTATION_LOCK_RETRY_DELAY_MS);
+        continue;
+      }
+      throw new Error(`Cannot safely recover malformed analysis active mutation lock: ${lockPath}`);
+    }
+    const ownerActive = await isActiveMutationLockOwnerActive(existing);
+    if (ownerActive === false) {
+      const recoveryToken = randomUUID();
+      let recoveryAcquired = false;
+      try {
+        await createActiveMutationLock(recoveryPath, repoPath, recoveryToken, processStartIdentity);
+        recoveryAcquired = true;
+      } catch (error: unknown) {
+        if (!isNodeError(error) || error.code !== 'EEXIST') throw error;
+      }
+      if (recoveryAcquired) {
+        try {
+          const current = await readActiveMutationLock(lockPath);
+          if (!current) {
+            if (await pathExists(lockPath)) {
+              throw new Error(
+                `Cannot safely recover malformed analysis active mutation lock: ${lockPath}`,
+              );
+            }
+            await createActiveMutationLock(lockPath, repoPath, token, processStartIdentity);
+            return;
+          }
+          const currentOwnerActive = await isActiveMutationLockOwnerActive(current);
+          if (currentOwnerActive === null) {
+            throw new Error(`Cannot safely recover analysis active mutation lock: ${lockPath}`);
+          }
+          if (currentOwnerActive === true) continue;
+          if (!(await removeActiveMutationLockIfOwner(lockPath, current))) {
+            throw new Error(`Cannot safely recover analysis active mutation lock: ${lockPath}`);
+          }
+          await createActiveMutationLock(lockPath, repoPath, token, processStartIdentity);
+          return;
+        } finally {
+          await releaseActiveMutationLock(recoveryPath, recoveryToken, processStartIdentity);
+        }
+      }
+    } else if (ownerActive === null) {
+      throw new Error(`Cannot safely validate analysis active mutation lock: ${lockPath}`);
+    }
+
+    if (attempt + 1 < ACTIVE_MUTATION_LOCK_MAX_ATTEMPTS) {
+      await delay(ACTIVE_MUTATION_LOCK_RETRY_DELAY_MS);
+    }
+  }
+  throw new Error(`Timed out acquiring analysis active mutation lock: ${lockPath}`);
+}
+
+async function createActiveMutationLock(
+  lockPath: string,
+  repoPath: string,
+  token: string,
+  processStartIdentity: string | null,
+): Promise<void> {
+  const record: ActiveMutationLockRecord = {
+    version: 1,
+    token,
+    pid: process.pid,
+    processStartIdentity: processStartIdentity ?? '',
+    acquiredAt: new Date().toISOString(),
+    repoPath,
+  };
+  const tempPath = `${lockPath}.${process.pid}.${token}.tmp`;
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  try {
+    handle = await fs.open(tempPath, 'wx', 0o600);
+    await handle.writeFile(`${JSON.stringify(record, null, 2)}\n`, { encoding: 'utf8' });
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await fs.link(tempPath, lockPath);
+  } finally {
+    await handle?.close().catch(() => {});
+    await fs.rm(tempPath, { force: true }).catch(() => {});
+  }
+}
+
+async function releaseActiveMutationLock(
+  lockPath: string,
+  token: string,
+  processStartIdentity: string | null,
+): Promise<void> {
+  const current = await readActiveMutationLock(lockPath);
+  if (
+    !current ||
+    current.token !== token ||
+    current.pid !== process.pid ||
+    current.processStartIdentity !== (processStartIdentity ?? '')
+  ) {
+    return;
+  }
+  await removeActiveMutationLockIfOwner(lockPath, current);
+}
+
+async function removeActiveMutationLockIfOwner(
+  lockPath: string,
+  expected: ActiveMutationLockRecord,
+): Promise<boolean> {
+  const current = await readActiveMutationLock(lockPath);
+  if (
+    !current ||
+    current.token !== expected.token ||
+    current.pid !== expected.pid ||
+    current.processStartIdentity !== expected.processStartIdentity
+  ) {
+    return false;
+  }
+  await fs.rm(lockPath, { force: true });
+  return true;
+}
+
+async function reclaimStaleRecoveryOwner(
+  recoveryPath: string,
+  expected: ActiveMutationLockRecord,
+  processStartIdentity: string | null,
+): Promise<boolean> {
+  const claimPath = `${recoveryPath}.claim.${process.pid}.${encodeRecoveryClaimIdentity(processStartIdentity)}.${randomUUID()}`;
+  try {
+    await fs.rename(recoveryPath, claimPath);
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === 'ENOENT') return false;
+    throw error;
+  }
+
+  const claimed = await readActiveMutationLock(claimPath);
+  if (!claimed) {
+    throw new Error(`Cannot safely recover malformed analysis lock recovery claim: ${claimPath}`);
+  }
+  if (!sameActiveMutationLockOwner(claimed, expected)) {
+    try {
+      await fs.link(claimPath, recoveryPath);
+    } catch (error: unknown) {
+      if (!isNodeError(error) || error.code !== 'EEXIST') throw error;
+    }
+    await fs.rm(claimPath, { force: true });
+    return false;
+  }
+  await fs.rm(claimPath, { force: true });
+  return true;
+}
+
+async function hasActiveRecoveryClaim(recoveryPath: string): Promise<boolean> {
+  const directory = path.dirname(recoveryPath);
+  const prefix = `${path.basename(recoveryPath)}.claim.`;
+  const entries = await fs.readdir(directory).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === 'ENOENT') return [];
+    throw error;
+  });
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix)) continue;
+    const claimPath = path.join(directory, entry);
+    const claim = await readActiveMutationLock(claimPath);
+    if (!claim) {
+      throw new Error(`Cannot safely recover malformed analysis lock recovery claim: ${claimPath}`);
+    }
+    const claimOwner = parseRecoveryClaimOwner(entry, prefix);
+    if (!claimOwner) {
+      throw new Error(`Cannot safely validate analysis lock recovery claim owner: ${claimPath}`);
+    }
+    const ownerActive = await isActiveMutationLockOwnerActive(claimOwner);
+    if (ownerActive === false) {
+      await fs.rm(claimPath, { force: true });
+      continue;
+    }
+    if (ownerActive === null) {
+      throw new Error(`Cannot safely validate analysis lock recovery claim: ${claimPath}`);
+    }
+    return true;
+  }
+  return false;
+}
+
+function encodeRecoveryClaimIdentity(processStartIdentity: string | null): string {
+  return processStartIdentity
+    ? Buffer.from(processStartIdentity, 'utf8').toString('hex')
+    : 'unavailable';
+}
+
+function parseRecoveryClaimOwner(entry: string, prefix: string): ActiveMutationLockRecord | null {
+  const [pidRaw, identityRaw, token] = entry.slice(prefix.length).split('.', 3);
+  const pid = Number(pidRaw);
+  if (!Number.isSafeInteger(pid) || pid <= 0 || !identityRaw || !token) return null;
+  let processStartIdentity = '';
+  if (identityRaw !== 'unavailable') {
+    if (!/^(?:[0-9a-f]{2})+$/i.test(identityRaw)) return null;
+    processStartIdentity = Buffer.from(identityRaw, 'hex').toString('utf8');
+    if (!processStartIdentity) return null;
+  }
+  return {
+    version: 1,
+    token,
+    pid,
+    processStartIdentity,
+    acquiredAt: '',
+    repoPath: '',
+  };
+}
+
+function sameActiveMutationLockOwner(
+  left: ActiveMutationLockRecord,
+  right: ActiveMutationLockRecord,
+): boolean {
+  return (
+    left.token === right.token &&
+    left.pid === right.pid &&
+    left.processStartIdentity === right.processStartIdentity
+  );
+}
+
+async function readActiveMutationLock(lockPath: string): Promise<ActiveMutationLockRecord | null> {
+  const raw = await fs.readFile(lockPath, 'utf8').catch((error: unknown) => {
+    if (isNodeError(error) && error.code === 'ENOENT') return null;
+    throw error;
+  });
+  if (raw === null) return null;
+  try {
+    const value = JSON.parse(raw) as Partial<ActiveMutationLockRecord>;
+    if (
+      value.version !== 1 ||
+      typeof value.token !== 'string' ||
+      typeof value.pid !== 'number' ||
+      !Number.isSafeInteger(value.pid) ||
+      value.pid <= 0 ||
+      typeof value.processStartIdentity !== 'string' ||
+      typeof value.acquiredAt !== 'string' ||
+      typeof value.repoPath !== 'string'
+    ) {
+      return null;
+    }
+    return value as ActiveMutationLockRecord;
   } catch {
     return null;
   }
 }
 
-async function clearActive(repoPath: string, expectedId?: string): Promise<void> {
-  if (expectedId) {
-    const current = await fs.readFile(activePath(repoPath), 'utf8').catch(() => '');
-    if (current.trim() !== expectedId) return;
+async function isActiveMutationLockOwnerActive(
+  record: ActiveMutationLockRecord,
+): Promise<boolean | null> {
+  try {
+    process.kill(record.pid, 0);
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === 'EPERM') return null;
+    return false;
   }
-  await fs.rm(activePath(repoPath), { force: true });
+  if (!record.processStartIdentity) return true;
+  const currentIdentity = await readProcessStartIdentity(record.pid);
+  if (!currentIdentity) return null;
+  return currentIdentity === record.processStartIdentity;
 }
 
 async function readProcessStartIdentity(pid: number): Promise<string | null> {
@@ -224,6 +1094,10 @@ function jobPath(repoPath: string, id: string): string {
 
 function activePath(repoPath: string): string {
   return path.join(jobsDir(repoPath), 'active');
+}
+
+function activeMutationLockPath(repoPath: string): string {
+  return path.join(jobsDir(repoPath), 'active.mutation.lock');
 }
 
 async function writeJob(job: AnalysisJobRecord): Promise<void> {
@@ -265,6 +1139,97 @@ function stableJson(value: unknown): string {
   return JSON.stringify(value) ?? 'null';
 }
 
+function validateRequestedCapabilities(requestedCapabilities: AnalysisRequestedCapabilities): void {
+  const graphCapabilities = requestedCapabilities.graphCapabilities;
+  if (
+    requestedCapabilities.version !== ANALYSIS_REQUESTED_CAPABILITIES_VERSION ||
+    requestedCapabilities.graph !== true ||
+    !Array.isArray(graphCapabilities) ||
+    graphCapabilities.length === 0 ||
+    graphCapabilities.some(
+      (capability) =>
+        capability !== 'symbols' && capability !== 'impact' && capability !== 'processes',
+    ) ||
+    graphCapabilities.some((capability, index) =>
+      index > 0 ? graphCapabilities[index - 1].localeCompare(capability) >= 0 : false,
+    ) ||
+    typeof requestedCapabilities.embeddings !== 'boolean' ||
+    (requestedCapabilities.embeddings
+      ? typeof requestedCapabilities.embeddingModelHash !== 'string' ||
+        requestedCapabilities.embeddingModelHash.trim().length === 0
+      : requestedCapabilities.embeddingModelHash !== null)
+  ) {
+    throw new Error('Invalid requested analysis capabilities.');
+  }
+}
+
+function validateSha256(value: unknown, fieldName: string): asserts value is string {
+  if (typeof value !== 'string' || !/^[0-9a-fA-F]{64}$/.test(value)) {
+    throw new Error(`${fieldName} must be a SHA-256 digest.`);
+  }
+}
+
+function validateSafeIdentifier(value: unknown, fieldName: string): asserts value is string {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)) {
+    throw new Error(`${fieldName} is malformed.`);
+  }
+}
+
+function validateTargetHead(targetHead: unknown): asserts targetHead is string {
+  if (typeof targetHead !== 'string' || !/^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/.test(targetHead)) {
+    throw new Error('Analysis target HEAD must be a 40- or 64-character git object identity.');
+  }
+}
+
+function validateSourceIdentity(
+  sourceIdentity: unknown,
+  targetHead: string,
+): asserts sourceIdentity is string {
+  if (typeof sourceIdentity !== 'string' || sourceIdentity !== `commit:${targetHead}`) {
+    throw new Error('Analysis source identity must match the requested target HEAD.');
+  }
+}
+
+function isCompatibleActiveRequest(
+  active: AnalysisJobRecord,
+  targetHead: string,
+  optionsDigest: string,
+  requestedCapabilities: AnalysisRequestedCapabilities,
+  sourceIdentity: string,
+  sourceManifestDigest: string,
+): boolean {
+  return (
+    active.sourceIdentity === sourceIdentity &&
+    active.sourceManifestDigest === sourceManifestDigest &&
+    active.targetHead === targetHead &&
+    active.optionsDigest === optionsDigest &&
+    sameRequestedCapabilities(active.requestedCapabilities, requestedCapabilities)
+  );
+}
+
+function cancellationRefusal(
+  job: AnalysisJobRecord | null,
+  reasonCode: AnalysisJobCancellationRefusalReason,
+  message: string,
+): AnalysisJobCancellationResult {
+  return { job, cancelled: false, refusal: { reasonCode, message } };
+}
+
 function digest(value: string): string {
   return createHash('sha256').update(value).digest('hex');
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  return fs.stat(filePath).then(
+    () => true,
+    () => false,
+  );
 }

--- a/ontoindex/src/core/analysis/analysis-job-runner.ts
+++ b/ontoindex/src/core/analysis/analysis-job-runner.ts
@@ -9,6 +9,7 @@ import {
 } from './analysis-coordinator.js';
 import {
   assertValidManagedAnalysisContext,
+  isValidSourceIdentity,
   MANAGED_ANALYSIS_ENV,
   type ManagedAnalysisContext,
 } from './analysis-publication-receipt.js';
@@ -200,8 +201,8 @@ function managedAnalysisEnvironment(job: AnalysisJobRecord): NodeJS.ProcessEnv {
 }
 
 function requireJobSourceIdentity(job: AnalysisJobRecord): string {
-  if (job.sourceIdentity !== `commit:${job.targetHead}`) {
-    throw new Error('Managed analysis job does not contain a valid clean source identity.');
+  if (!isValidSourceIdentity(job.sourceIdentity, job.targetHead, job.sourceManifestDigest)) {
+    throw new Error('Managed analysis job does not contain a valid source identity.');
   }
   return job.sourceIdentity;
 }

--- a/ontoindex/src/core/analysis/analysis-job-runner.ts
+++ b/ontoindex/src/core/analysis/analysis-job-runner.ts
@@ -2,24 +2,31 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 
 import {
+  claimAnalysisJobRunner,
   completeAnalysisJob,
-  writeAnalysisJob,
   type AnalysisJobRecord,
+  type AnalysisJobRunnerOwner,
 } from './analysis-coordinator.js';
+import {
+  assertValidManagedAnalysisContext,
+  MANAGED_ANALYSIS_ENV,
+  type ManagedAnalysisContext,
+} from './analysis-publication-receipt.js';
 
 const MAX_LOG_BYTES = 1024 * 1024;
 const JOB_TIMEOUT_MS = 30 * 60 * 1000;
 const KILL_GRACE_MS = 5_000;
+const PROCESS_GROUP_EXIT_TIMEOUT_MS = KILL_GRACE_MS + 5_000;
+const PROCESS_GROUP_POLL_INTERVAL_MS = 25;
+let runnerClaim: AnalysisJobRecord | null = null;
 
 async function main(): Promise<void> {
   const jobFile = process.argv[2];
   if (!jobFile) throw new Error('analysis job file is required');
-  const job = JSON.parse(await fs.readFile(jobFile, 'utf8')) as AnalysisJobRecord;
-  job.status = 'running';
-  job.runnerPid = process.pid;
-  job.runnerProcessStartIdentity = await readProcessStartIdentity(process.pid);
-  job.startedAt = new Date().toISOString();
-  await writeAnalysisJob(job);
+  const job = await claimAnalysisJobRunner(jobFile);
+  if (!job) return;
+  runnerClaim = job;
+  const expectedRunner = runnerOwner(job);
 
   // Assigned after cancellation handlers are defined so early signals remain safe.
   // eslint-disable-next-line prefer-const
@@ -56,6 +63,7 @@ async function main(): Promise<void> {
     cwd: job.repoPath,
     detached: process.platform !== 'win32',
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: managedAnalysisEnvironment(job),
   });
   if (cancelling) stopChild();
   const timeout = setTimeout(() => cancel('Analysis timed out (30 minute limit)'), JOB_TIMEOUT_MS);
@@ -67,11 +75,15 @@ async function main(): Promise<void> {
     terminal = true;
     clearTimeout(timeout);
     await appendQueue.catch(() => {});
-    await completeAnalysisJob(jobFile, {
-      status: 'failed',
-      completedAt: new Date().toISOString(),
-      error: error.message,
-    });
+    await completeAnalysisJob(
+      jobFile,
+      {
+        status: 'failed',
+        completedAt: new Date().toISOString(),
+        error: error.message,
+      },
+      expectedRunner,
+    );
   });
   child.once('exit', async (code, signal) => {
     if (terminal) return;
@@ -79,33 +91,45 @@ async function main(): Promise<void> {
     clearTimeout(timeout);
     await appendQueue.catch(() => {});
     if (cancelling) {
-      await waitForAnalyzerGroupExit(child.pid);
+      const analyzerGroupStopped = await waitForAnalyzerGroupExit(child.pid);
       if (killTimer) clearTimeout(killTimer);
-      await completeAnalysisJob(jobFile, {
-        status: 'cancelled',
+      await completeAnalysisJob(
+        jobFile,
+        {
+          status: analyzerGroupStopped ? 'cancelled' : 'failed',
+          completedAt: new Date().toISOString(),
+          exitCode: code,
+          signal,
+          error: analyzerGroupStopped
+            ? (job.error ?? 'Analysis cancelled')
+            : `Analysis process group remained active after ${PROCESS_GROUP_EXIT_TIMEOUT_MS}ms shutdown limit.`,
+        },
+        expectedRunner,
+      );
+      process.exitCode = analyzerGroupStopped ? 143 : 1;
+      return;
+    }
+    await completeAnalysisJob(
+      jobFile,
+      {
+        status: code === 0 ? 'complete' : 'failed',
         completedAt: new Date().toISOString(),
         exitCode: code,
         signal,
-        error: job.error ?? 'Analysis cancelled',
-      });
-      process.exitCode = 143;
-      return;
-    }
-    await completeAnalysisJob(jobFile, {
-      status: code === 0 ? 'complete' : 'failed',
-      completedAt: new Date().toISOString(),
-      exitCode: code,
-      signal,
-      ...(code === 0 ? {} : { error: `analyze exited with code ${code ?? 'null'}` }),
-    });
+        ...(code === 0 ? {} : { error: `analyze exited with code ${code ?? 'null'}` }),
+      },
+      expectedRunner,
+    );
   });
 }
 
-async function waitForAnalyzerGroupExit(pid: number | undefined): Promise<void> {
-  if (process.platform === 'win32' || !pid) return;
-  while (isProcessGroupAlive(pid)) {
-    await new Promise((resolve) => setTimeout(resolve, 25));
+async function waitForAnalyzerGroupExit(pid: number | undefined): Promise<boolean> {
+  if (process.platform === 'win32' || !pid) return true;
+  const deadline = Date.now() + PROCESS_GROUP_EXIT_TIMEOUT_MS;
+  while (isProcessGroupAlive(pid) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, PROCESS_GROUP_POLL_INTERVAL_MS));
   }
+  return !isProcessGroupAlive(pid);
 }
 
 function isProcessGroupAlive(pid: number): boolean {
@@ -139,14 +163,61 @@ async function readProcessStartIdentity(pid: number): Promise<string | undefined
   }
 }
 
+function runnerOwner(job: AnalysisJobRecord): AnalysisJobRunnerOwner {
+  if (job.runnerPid === undefined) throw new Error('Managed analysis runner claim is incomplete.');
+  return {
+    pid: job.runnerPid,
+    processStartIdentity: job.runnerProcessStartIdentity,
+  };
+}
+
+function managedAnalysisEnvironment(job: AnalysisJobRecord): NodeJS.ProcessEnv {
+  const context: ManagedAnalysisContext = {
+    jobId: job.id,
+    targetHead: job.targetHead,
+    optionsDigest: job.optionsDigest,
+    sourceIdentity: requireJobSourceIdentity(job),
+    sourceManifestDigest: job.sourceManifestDigest,
+    requestedCapabilities: job.requestedCapabilities,
+  };
+  assertValidManagedAnalysisContext(context);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    [MANAGED_ANALYSIS_ENV.jobId]: context.jobId,
+    [MANAGED_ANALYSIS_ENV.targetHead]: context.targetHead,
+    [MANAGED_ANALYSIS_ENV.optionsDigest]: context.optionsDigest,
+    [MANAGED_ANALYSIS_ENV.sourceIdentity]: context.sourceIdentity,
+    [MANAGED_ANALYSIS_ENV.sourceManifestDigest]: context.sourceManifestDigest,
+    [MANAGED_ANALYSIS_ENV.requestedCapabilities]: JSON.stringify(context.requestedCapabilities),
+  };
+  if (context.requestedCapabilities.embeddings) {
+    env.ONTOINDEX_EMBEDDING_MODEL_HASH = context.requestedCapabilities.embeddingModelHash as string;
+  } else {
+    delete env.ONTOINDEX_EMBEDDING_MODEL_HASH;
+  }
+  return env;
+}
+
+function requireJobSourceIdentity(job: AnalysisJobRecord): string {
+  if (job.sourceIdentity !== `commit:${job.targetHead}`) {
+    throw new Error('Managed analysis job does not contain a valid clean source identity.');
+  }
+  return job.sourceIdentity;
+}
+
 void main().catch(async (error: unknown) => {
   const jobFile = process.argv[2];
-  if (jobFile) {
-    await completeAnalysisJob(jobFile, {
-      status: 'failed',
-      completedAt: new Date().toISOString(),
-      error: error instanceof Error ? error.message : String(error),
-    }).catch(() => {});
+  if (jobFile && runnerClaim) {
+    await completeAnalysisJob(
+      jobFile,
+      {
+        status: 'failed',
+        completedAt: new Date().toISOString(),
+        error: error instanceof Error ? error.message : String(error),
+      },
+      runnerOwner(runnerClaim),
+    ).catch(() => {});
   }
   process.exitCode = 1;
 });

--- a/ontoindex/src/core/analysis/analysis-publication-receipt.ts
+++ b/ontoindex/src/core/analysis/analysis-publication-receipt.ts
@@ -1,0 +1,269 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { SOURCE_MANIFEST_CONTRACT } from '../indexing/source-manifest.js';
+
+export const ANALYSIS_REQUESTED_CAPABILITIES_VERSION = 1 as const;
+export const ANALYSIS_PUBLICATION_RECEIPT_VERSION = 1 as const;
+
+export const MANAGED_ANALYSIS_ENV = {
+  jobId: 'ONTOINDEX_ANALYSIS_JOB_ID',
+  targetHead: 'ONTOINDEX_ANALYSIS_TARGET_HEAD',
+  optionsDigest: 'ONTOINDEX_ANALYSIS_OPTIONS_DIGEST',
+  sourceIdentity: 'ONTOINDEX_ANALYSIS_SOURCE_IDENTITY',
+  sourceManifestDigest: 'ONTOINDEX_ANALYSIS_SOURCE_MANIFEST_DIGEST',
+  requestedCapabilities: 'ONTOINDEX_ANALYSIS_REQUESTED_CAPABILITIES',
+} as const;
+
+const RECEIPT_DIRECTORY = 'analysis-receipts';
+const MAX_RECEIPT_BYTES = 64 * 1024;
+const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const GIT_HEAD = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/;
+const SHA256_DIGEST = /^[0-9a-fA-F]{64}$/;
+
+/** Version 1 of the capabilities requested by a managed analysis job. */
+export type AnalysisGraphCapability = 'symbols' | 'impact' | 'processes';
+export type AnalysisRequestedCapabilities = {
+  version: typeof ANALYSIS_REQUESTED_CAPABILITIES_VERSION;
+  graph: true;
+  graphCapabilities: AnalysisGraphCapability[];
+  embeddings: boolean;
+  embeddingModelHash: string | null;
+};
+
+export interface ManagedAnalysisContext {
+  jobId: string;
+  targetHead: string;
+  optionsDigest: string;
+  sourceIdentity: string;
+  sourceManifestDigest: string;
+  requestedCapabilities: AnalysisRequestedCapabilities;
+}
+
+export interface AnalysisPublicationReceipt {
+  version: typeof ANALYSIS_PUBLICATION_RECEIPT_VERSION;
+  jobId: string;
+  repoPath: string;
+  targetHead: string;
+  optionsDigest: string;
+  sourceIdentity: string;
+  sourceManifestDigest: string;
+  generationId: string;
+  requestedCapabilities: AnalysisRequestedCapabilities;
+  analyzerContractVersion: typeof SOURCE_MANIFEST_CONTRACT;
+  publishedAt: string;
+}
+
+export function parseManagedAnalysisContextFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ManagedAnalysisContext | undefined {
+  const raw = {
+    jobId: env[MANAGED_ANALYSIS_ENV.jobId],
+    targetHead: env[MANAGED_ANALYSIS_ENV.targetHead],
+    optionsDigest: env[MANAGED_ANALYSIS_ENV.optionsDigest],
+    sourceIdentity: env[MANAGED_ANALYSIS_ENV.sourceIdentity],
+    sourceManifestDigest: env[MANAGED_ANALYSIS_ENV.sourceManifestDigest],
+    requestedCapabilities: env[MANAGED_ANALYSIS_ENV.requestedCapabilities],
+  };
+  const presentCount = Object.values(raw).filter((value) => value !== undefined).length;
+  if (presentCount === 0) return undefined;
+  if (presentCount !== Object.keys(raw).length) {
+    throw new Error('Managed analysis context is incomplete.');
+  }
+
+  let requestedCapabilities: unknown;
+  try {
+    const serialized = raw.requestedCapabilities as string;
+    if (serialized.length > 1024) throw new Error('capabilities payload is too large');
+    requestedCapabilities = JSON.parse(serialized);
+  } catch {
+    throw new Error('Managed analysis requested capabilities are malformed.');
+  }
+
+  const context: ManagedAnalysisContext = {
+    jobId: (raw.jobId as string).trim(),
+    targetHead: (raw.targetHead as string).trim(),
+    optionsDigest: (raw.optionsDigest as string).trim(),
+    sourceIdentity: (raw.sourceIdentity as string).trim(),
+    sourceManifestDigest: (raw.sourceManifestDigest as string).trim(),
+    requestedCapabilities: requireRequestedCapabilities(requestedCapabilities),
+  };
+  assertValidManagedAnalysisContext(context);
+  return context;
+}
+
+export function assertValidManagedAnalysisContext(
+  context: ManagedAnalysisContext,
+): asserts context is ManagedAnalysisContext {
+  requireSafeIdentifier(context.jobId, 'managed analysis job id');
+  requireGitHead(context.targetHead, 'managed analysis target HEAD');
+  requireSha256(context.optionsDigest, 'managed analysis options digest');
+  requireSourceIdentity(context.sourceIdentity, context.targetHead);
+  requireSha256(context.sourceManifestDigest, 'managed analysis source manifest digest');
+  requireRequestedCapabilities(context.requestedCapabilities);
+}
+
+export function analysisPublicationReceiptPath(generationPath: string, jobId: string): string {
+  const safeJobId = requireSafeIdentifier(jobId, 'analysis receipt job id');
+  return path.join(path.resolve(generationPath), RECEIPT_DIRECTORY, `${safeJobId}.json`);
+}
+
+export async function writeAnalysisPublicationReceipt(
+  generationPath: string,
+  receipt: AnalysisPublicationReceipt,
+): Promise<string> {
+  const validated = requireAnalysisPublicationReceipt(receipt);
+  const receiptPath = analysisPublicationReceiptPath(generationPath, validated.jobId);
+  const receiptDirectory = path.dirname(receiptPath);
+  await fs.mkdir(receiptDirectory, { recursive: true, mode: 0o700 });
+  const temporaryPath = path.join(
+    receiptDirectory,
+    `.${path.basename(receiptPath)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  try {
+    await fs.writeFile(temporaryPath, `${JSON.stringify(validated, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    await fs.rename(temporaryPath, receiptPath);
+  } catch (error) {
+    await fs.rm(temporaryPath, { force: true }).catch(() => {});
+    throw error;
+  }
+  return receiptPath;
+}
+
+/**
+ * Read a receipt from a caller-resolved active generation. Missing, malformed,
+ * oversized, or identity-mismatched receipts fail closed as `null`.
+ */
+export async function readAnalysisPublicationReceipt(
+  activeGenerationPath: string,
+  jobId: string,
+): Promise<AnalysisPublicationReceipt | null> {
+  try {
+    const receiptPath = analysisPublicationReceiptPath(activeGenerationPath, jobId);
+    const stat = await fs.stat(receiptPath);
+    if (!stat.isFile() || stat.size <= 0 || stat.size > MAX_RECEIPT_BYTES) return null;
+    const parsed: unknown = JSON.parse(await fs.readFile(receiptPath, 'utf8'));
+    const receipt = requireAnalysisPublicationReceipt(parsed);
+    return receipt.jobId === jobId ? receipt : null;
+  } catch {
+    return null;
+  }
+}
+
+function requireAnalysisPublicationReceipt(value: unknown): AnalysisPublicationReceipt {
+  if (!isRecord(value)) throw new Error('Analysis publication receipt is malformed.');
+  if (value.version !== ANALYSIS_PUBLICATION_RECEIPT_VERSION) {
+    throw new Error('Analysis publication receipt version is unsupported.');
+  }
+  const repoPath = requireNonEmptyString(value.repoPath, 'analysis receipt repository path');
+  if (!path.isAbsolute(repoPath) || path.resolve(repoPath) !== repoPath) {
+    throw new Error('Analysis receipt repository path must be resolved.');
+  }
+  const publishedAt = requireNonEmptyString(value.publishedAt, 'analysis receipt publication time');
+  if (!Number.isFinite(Date.parse(publishedAt))) {
+    throw new Error('Analysis receipt publication time is malformed.');
+  }
+  if (value.analyzerContractVersion !== SOURCE_MANIFEST_CONTRACT) {
+    throw new Error('Analysis receipt analyzer contract is unsupported.');
+  }
+
+  const targetHead = requireGitHead(value.targetHead, 'analysis receipt target HEAD');
+  return {
+    version: ANALYSIS_PUBLICATION_RECEIPT_VERSION,
+    jobId: requireSafeIdentifier(value.jobId, 'analysis receipt job id'),
+    repoPath,
+    targetHead,
+    optionsDigest: requireSha256(value.optionsDigest, 'analysis receipt options digest'),
+    sourceIdentity: requireSourceIdentity(value.sourceIdentity, targetHead),
+    sourceManifestDigest: requireSha256(
+      value.sourceManifestDigest,
+      'analysis receipt source manifest digest',
+    ),
+    generationId: requireSafeIdentifier(value.generationId, 'analysis receipt generation id'),
+    requestedCapabilities: requireRequestedCapabilities(value.requestedCapabilities),
+    analyzerContractVersion: SOURCE_MANIFEST_CONTRACT,
+    publishedAt,
+  };
+}
+
+function requireRequestedCapabilities(value: unknown): AnalysisRequestedCapabilities {
+  if (
+    !isRecord(value) ||
+    value.version !== ANALYSIS_REQUESTED_CAPABILITIES_VERSION ||
+    value.graph !== true ||
+    !Array.isArray(value.graphCapabilities) ||
+    typeof value.embeddings !== 'boolean'
+  ) {
+    throw new Error('Managed analysis requested capabilities are malformed.');
+  }
+  const graphCapabilities = [...new Set(value.graphCapabilities)].sort();
+  if (
+    graphCapabilities.length === 0 ||
+    graphCapabilities.length !== value.graphCapabilities.length ||
+    graphCapabilities.some(
+      (capability) =>
+        capability !== 'symbols' && capability !== 'impact' && capability !== 'processes',
+    ) ||
+    graphCapabilities.some((capability, index) => capability !== value.graphCapabilities[index])
+  ) {
+    throw new Error('Managed analysis requested capabilities are malformed.');
+  }
+  const embeddingModelHash = value.embeddingModelHash;
+  if (
+    (value.embeddings &&
+      (typeof embeddingModelHash !== 'string' || embeddingModelHash.trim().length === 0)) ||
+    (!value.embeddings && embeddingModelHash !== null)
+  ) {
+    throw new Error('Managed analysis requested capabilities are malformed.');
+  }
+  return {
+    version: ANALYSIS_REQUESTED_CAPABILITIES_VERSION,
+    graph: true,
+    graphCapabilities: graphCapabilities as AnalysisGraphCapability[],
+    embeddings: value.embeddings,
+    embeddingModelHash: value.embeddings ? (embeddingModelHash as string).trim() : null,
+  };
+}
+
+function requireSafeIdentifier(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !SAFE_IDENTIFIER.test(value)) {
+    throw new Error(`${fieldName} is malformed.`);
+  }
+  return value;
+}
+
+function requireGitHead(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !GIT_HEAD.test(value)) {
+    throw new Error(`${fieldName} is malformed.`);
+  }
+  return value;
+}
+
+function requireSha256(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !SHA256_DIGEST.test(value)) {
+    throw new Error(`${fieldName} is malformed.`);
+  }
+  return value;
+}
+
+function requireSourceIdentity(value: unknown, targetHead: string): string {
+  if (value !== `commit:${targetHead}`) {
+    throw new Error('Managed analysis source identity is malformed.');
+  }
+  return value;
+}
+
+function requireNonEmptyString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${fieldName} is malformed.`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/ontoindex/src/core/analysis/analysis-publication-receipt.ts
+++ b/ontoindex/src/core/analysis/analysis-publication-receipt.ts
@@ -21,6 +21,33 @@ const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const GIT_HEAD = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/;
 const SHA256_DIGEST = /^[0-9a-fA-F]{64}$/;
 
+/**
+ * Analysis source identity has two legal forms. `commit:<head>` means the
+ * analyzed bytes matched a clean checkout of that commit. `worktree:<digest>`
+ * means the analyzed bytes were the working tree, identified by the source
+ * manifest digest that hashed those exact file contents. A dirty tree must
+ * never be published under a commit identity it does not match.
+ */
+export function commitSourceIdentity(targetHead: string): string {
+  return `commit:${targetHead}`;
+}
+
+export function worktreeSourceIdentity(sourceManifestDigest: string): string {
+  return `worktree:${sourceManifestDigest}`;
+}
+
+export function isValidSourceIdentity(
+  value: unknown,
+  targetHead: string,
+  sourceManifestDigest: string,
+): value is string {
+  if (typeof value !== 'string') return false;
+  if (value === commitSourceIdentity(targetHead)) return true;
+  return SHA256_DIGEST.test(sourceManifestDigest)
+    ? value === worktreeSourceIdentity(sourceManifestDigest)
+    : false;
+}
+
 /** Version 1 of the capabilities requested by a managed analysis job. */
 export type AnalysisGraphCapability = 'symbols' | 'impact' | 'processes';
 export type AnalysisRequestedCapabilities = {
@@ -98,8 +125,8 @@ export function assertValidManagedAnalysisContext(
   requireSafeIdentifier(context.jobId, 'managed analysis job id');
   requireGitHead(context.targetHead, 'managed analysis target HEAD');
   requireSha256(context.optionsDigest, 'managed analysis options digest');
-  requireSourceIdentity(context.sourceIdentity, context.targetHead);
   requireSha256(context.sourceManifestDigest, 'managed analysis source manifest digest');
+  requireSourceIdentity(context.sourceIdentity, context.targetHead, context.sourceManifestDigest);
   requireRequestedCapabilities(context.requestedCapabilities);
 }
 
@@ -172,17 +199,18 @@ function requireAnalysisPublicationReceipt(value: unknown): AnalysisPublicationR
   }
 
   const targetHead = requireGitHead(value.targetHead, 'analysis receipt target HEAD');
+  const sourceManifestDigest = requireSha256(
+    value.sourceManifestDigest,
+    'analysis receipt source manifest digest',
+  );
   return {
     version: ANALYSIS_PUBLICATION_RECEIPT_VERSION,
     jobId: requireSafeIdentifier(value.jobId, 'analysis receipt job id'),
     repoPath,
     targetHead,
     optionsDigest: requireSha256(value.optionsDigest, 'analysis receipt options digest'),
-    sourceIdentity: requireSourceIdentity(value.sourceIdentity, targetHead),
-    sourceManifestDigest: requireSha256(
-      value.sourceManifestDigest,
-      'analysis receipt source manifest digest',
-    ),
+    sourceIdentity: requireSourceIdentity(value.sourceIdentity, targetHead, sourceManifestDigest),
+    sourceManifestDigest,
     generationId: requireSafeIdentifier(value.generationId, 'analysis receipt generation id'),
     requestedCapabilities: requireRequestedCapabilities(value.requestedCapabilities),
     analyzerContractVersion: SOURCE_MANIFEST_CONTRACT,
@@ -250,8 +278,12 @@ function requireSha256(value: unknown, fieldName: string): string {
   return value;
 }
 
-function requireSourceIdentity(value: unknown, targetHead: string): string {
-  if (value !== `commit:${targetHead}`) {
+function requireSourceIdentity(
+  value: unknown,
+  targetHead: string,
+  sourceManifestDigest: string,
+): string {
+  if (!isValidSourceIdentity(value, targetHead, sourceManifestDigest)) {
     throw new Error('Managed analysis source identity is malformed.');
   }
   return value;

--- a/ontoindex/src/core/audit-lifecycle/audit-event-store.ts
+++ b/ontoindex/src/core/audit-lifecycle/audit-event-store.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 
 import { buildAuditProjection } from './audit-projection.js';
@@ -20,7 +21,10 @@ import {
   type AuditSessionInput,
 } from './audit-session.js';
 
-export const AUDIT_EVENT_STORE_SCHEMA_VERSION = 1;
+export const AUDIT_EVENT_STORE_SCHEMA_VERSION = 2;
+export const AUDIT_EVENT_STORE_LEGACY_SCHEMA_VERSION = 1;
+export const AUDIT_EVENT_INTEGRITY_VERSION = 2;
+export const AUDIT_EVENT_STORE_GENESIS_PREVIOUS_CHECKSUM = 'GENESIS';
 export const AUDIT_EVENT_STORE_RELATIVE_PATH = path.join(
   '.ontoindex',
   'audit',
@@ -108,8 +112,39 @@ export type AuditEvent =
   | AuditLintedEvent;
 
 export interface AuditEventStoreState {
-  schemaVersion: typeof AUDIT_EVENT_STORE_SCHEMA_VERSION;
+  schemaVersion: 1 | typeof AUDIT_EVENT_STORE_SCHEMA_VERSION;
   events: AuditEvent[];
+  integrity?: AuditEventStoreIntegrity;
+  legacyPrefixLength?: number;
+  migratedAt?: string;
+}
+
+export type AuditEventStoreIntegrityStatus =
+  | 'VALID'
+  | 'BROKEN'
+  | 'LEGACY_UNVERIFIED'
+  | 'VALID_WITH_LEGACY_PREFIX';
+
+export interface AuditEventStoreIntegrity {
+  status: AuditEventStoreIntegrityStatus;
+  firstBrokenSequence?: number;
+  reason?: string;
+}
+
+export interface AuditEventStoreRawInspection {
+  exists: boolean;
+  bytes: Buffer | null;
+  sha256: string | null;
+  parsed: unknown;
+  parseError: string | null;
+}
+
+export interface AuditEventStoreRecoveryResult {
+  archivePath: string;
+  archiveSha256: string;
+  archiveBytes: number;
+  statePath: string;
+  projectionPath: string;
 }
 
 export interface AuditEventInput {
@@ -145,10 +180,13 @@ export class LocalAuditEventStore {
   async appendEvent(event: AuditEvent, options: AuditStoreUpdateOptions = {}): Promise<AuditEvent> {
     return withAuditStoreUpdateLock(this.eventStorePath, options, async () => {
       const state = await this.load();
+      assertWritableChain(state);
       assertUniqueEventId(state.events, event.id);
       const nextEvent = normalizeAuditEvent(event);
-      state.events.push(nextEvent);
-      await saveAuditEventStoreState(this.eventStorePath, state);
+      await saveAuditEventStoreState(this.eventStorePath, {
+        ...state,
+        events: [...state.events, nextEvent],
+      });
       await rebuildAuditProjectionFile(this.eventStorePath, this.projectionPath);
       return nextEvent;
     });
@@ -223,7 +261,33 @@ export async function saveAuditEventStoreState(
   stateFilePath: string,
   state: AuditEventStoreState,
 ): Promise<void> {
-  await atomicWriteJson(stateFilePath, normalizeAuditEventStoreState(state));
+  const current = await inspectAuditEventStoreRaw(stateFilePath);
+  if (current.exists && current.parsed === null) {
+    throw new Error('cannot save over malformed audit event store');
+  }
+  if (current.parsed !== null) {
+    const currentState = normalizeAuditEventStoreState(current.parsed, false);
+    if (currentState.integrity?.status === 'BROKEN') {
+      throw new Error(
+        `cannot save audit event store with broken on-disk chain at sequence ${currentState.integrity.firstBrokenSequence ?? 'unknown'}`,
+      );
+    }
+    assertWritableChain(currentState);
+  }
+  assertWritableChain(state);
+  const normalized = normalizeAuditEventStoreState(state, true);
+  await atomicWriteJson(stateFilePath, serializeAuditEventStoreState(normalized));
+}
+
+// Unverifiable history is read-only. Migrating it in place would re-sign events
+// the chain never covered, so a legacy store must be archived and re-ingested
+// rather than blessed by an ordinary append.
+function assertWritableChain(state: AuditEventStoreState): void {
+  if (state.integrity?.status === 'LEGACY_UNVERIFIED') {
+    throw new Error(
+      'cannot write to an unverified legacy audit event store; archive it with `ontoindex audit integrity --reset-broken --acknowledge-data-loss` and re-ingest',
+    );
+  }
 }
 
 export async function rebuildAuditProjectionFile(
@@ -239,7 +303,86 @@ export function createEmptyAuditEventStoreState(): AuditEventStoreState {
   return {
     schemaVersion: AUDIT_EVENT_STORE_SCHEMA_VERSION,
     events: [],
+    integrity: { status: 'VALID' },
   };
+}
+
+export async function inspectAuditEventStoreRaw(
+  stateFilePath: string,
+): Promise<AuditEventStoreRawInspection> {
+  let bytes: Buffer;
+  try {
+    bytes = await fs.readFile(stateFilePath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return { exists: false, bytes: null, sha256: null, parsed: null, parseError: null };
+    }
+    throw error;
+  }
+  const sha256 = digest(bytes);
+  try {
+    return {
+      exists: true,
+      bytes,
+      sha256,
+      parsed: JSON.parse(bytes.toString('utf8')),
+      parseError: null,
+    };
+  } catch (error) {
+    return {
+      exists: true,
+      bytes,
+      sha256,
+      parsed: null,
+      parseError: (error as Error).message,
+    };
+  }
+}
+
+export async function recoverAuditEventStore(
+  stateFilePath: string,
+  projectionPath: string,
+  options: AuditStoreUpdateOptions = {},
+): Promise<AuditEventStoreRecoveryResult> {
+  return withAuditStoreUpdateLock(stateFilePath, options, async () => {
+    const raw = await inspectAuditEventStoreRaw(stateFilePath);
+    if (!raw.exists || raw.bytes === null || raw.sha256 === null) {
+      throw new Error('cannot recover missing audit event store');
+    }
+    if (raw.parsed !== null) {
+      let integrity: AuditEventStoreIntegrity | undefined;
+      try {
+        integrity = normalizeAuditEventStoreState(raw.parsed, false).integrity;
+      } catch {
+        integrity = undefined;
+      }
+      // Healthy stores stay protected; BROKEN and LEGACY_UNVERIFIED are exactly
+      // the states an operator must be able to archive and re-ingest.
+      if (
+        integrity !== undefined &&
+        integrity.status !== 'BROKEN' &&
+        integrity.status !== 'LEGACY_UNVERIFIED'
+      ) {
+        throw new Error(`cannot recover audit event store with ${integrity.status} integrity`);
+      }
+    }
+    const archivePath = path.join(
+      path.dirname(stateFilePath),
+      'recovery',
+      `audit-event-store-${Date.now()}-${raw.sha256.slice(0, 12)}.json`,
+    );
+    await fs.mkdir(path.dirname(archivePath), { recursive: true });
+    await fs.writeFile(archivePath, raw.bytes);
+    await atomicWriteJson(stateFilePath, createEmptyAuditEventStoreState());
+    await atomicWriteJson(projectionPath, buildAuditProjection([]));
+    return {
+      archivePath,
+      archiveSha256: raw.sha256,
+      archiveBytes: raw.bytes.length,
+      statePath: stateFilePath,
+      projectionPath,
+    };
+  });
 }
 
 export function getAuditEventStorePath(repoRoot: string): string {
@@ -250,10 +393,16 @@ export function getAuditProjectionPath(repoRoot: string): string {
   return path.join(repoRoot, AUDIT_PROJECTION_RELATIVE_PATH);
 }
 
-function normalizeAuditEventStoreState(value: unknown): AuditEventStoreState {
+function normalizeAuditEventStoreState(
+  value: unknown,
+  migrate: boolean = true,
+): AuditEventStoreState {
   const record = requireObject(value, 'audit event store');
   const schemaVersion = requireNumber(record.schemaVersion, 'schemaVersion');
-  if (schemaVersion !== AUDIT_EVENT_STORE_SCHEMA_VERSION) {
+  if (
+    schemaVersion !== AUDIT_EVENT_STORE_SCHEMA_VERSION &&
+    schemaVersion !== AUDIT_EVENT_STORE_LEGACY_SCHEMA_VERSION
+  ) {
     throw new Error(`unsupported audit event store schemaVersion: ${schemaVersion}`);
   }
   const events = requireArray(record.events, 'events').map((event) => normalizeAuditEvent(event));
@@ -264,7 +413,170 @@ function normalizeAuditEventStoreState(value: unknown): AuditEventStoreState {
     }
     seen.add(event.id);
   }
-  return { schemaVersion: AUDIT_EVENT_STORE_SCHEMA_VERSION, events };
+  const rawRecords = requireArray(record.events, 'events');
+  // schemaVersion is caller-controlled and outside the checksum, so it cannot
+  // authorize skipping verification. Any surviving integrity envelope is proof
+  // the store was written as v2 and must still verify as v2.
+  const carriesIntegrityEnvelope = rawRecords.some(
+    (event) =>
+      typeof event === 'object' &&
+      event !== null &&
+      ('checksum' in event || 'sequence' in event || 'previousChecksum' in event),
+  );
+  if (schemaVersion === AUDIT_EVENT_STORE_LEGACY_SCHEMA_VERSION && !carriesIntegrityEnvelope) {
+    return {
+      schemaVersion: AUDIT_EVENT_STORE_LEGACY_SCHEMA_VERSION,
+      events,
+      integrity: { status: 'LEGACY_UNVERIFIED' },
+    };
+  }
+  const rawEvents = rawRecords;
+  // Non-empty schema-v2 stores must carry complete integrity envelopes. Missing
+  // fields are BROKEN, never silently treated as valid and re-signed on save.
+  const integrity = verifyIntegrity(rawEvents, events, record.legacyPrefixLength);
+  const state: AuditEventStoreState = {
+    schemaVersion: AUDIT_EVENT_STORE_SCHEMA_VERSION,
+    events,
+    integrity,
+    ...(typeof record.legacyPrefixLength === 'number'
+      ? { legacyPrefixLength: requireNumber(record.legacyPrefixLength, 'legacyPrefixLength') }
+      : {}),
+    ...(typeof record.migratedAt === 'string' ? { migratedAt: record.migratedAt } : {}),
+  };
+  void migrate;
+  return state;
+}
+
+function serializeAuditEventStoreState(state: AuditEventStoreState): Record<string, unknown> {
+  const normalizedEvents = state.events.map((event) => normalizeAuditEvent(event));
+  const entries = buildIntegrityEntries(normalizedEvents, state.legacyPrefixLength ?? 0);
+  return {
+    schemaVersion: AUDIT_EVENT_STORE_SCHEMA_VERSION,
+    ...(state.legacyPrefixLength !== undefined
+      ? { legacyPrefixLength: state.legacyPrefixLength }
+      : {}),
+    ...(state.migratedAt !== undefined ? { migratedAt: state.migratedAt } : {}),
+    events: entries,
+  };
+}
+
+function verifyIntegrity(
+  rawEvents: unknown[],
+  normalizedEvents: AuditEvent[],
+  legacyPrefixLengthValue: unknown,
+): AuditEventStoreIntegrity {
+  const records = rawEvents.map((event) => requireObject(event, 'event'));
+  let legacyPrefixLength = 0;
+  if (legacyPrefixLengthValue !== undefined) {
+    try {
+      legacyPrefixLength = requireNumber(legacyPrefixLengthValue, 'legacyPrefixLength');
+    } catch {
+      return { status: 'BROKEN', firstBrokenSequence: 0, reason: 'invalid-legacy-prefix-length' };
+    }
+    if (legacyPrefixLength < 0 || legacyPrefixLength > records.length) {
+      return { status: 'BROKEN', firstBrokenSequence: 0, reason: 'invalid-legacy-prefix-length' };
+    }
+  }
+  let previousChecksum = AUDIT_EVENT_STORE_GENESIS_PREVIOUS_CHECKSUM;
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (
+      record.sequence === undefined ||
+      record.checksum === undefined ||
+      record.previousChecksum === undefined
+    ) {
+      return {
+        status: 'BROKEN',
+        firstBrokenSequence: index,
+        reason: 'missing-integrity-envelope',
+      };
+    }
+    let sequence: number;
+    let checksum: string;
+    let previous: string;
+    try {
+      sequence = requireNumber(record.sequence, `events[${index}].sequence`);
+      checksum = requireRecordString(record, 'checksum', `events[${index}].checksum`);
+      previous = requireRecordString(
+        record,
+        'previousChecksum',
+        `events[${index}].previousChecksum`,
+      );
+    } catch {
+      return {
+        status: 'BROKEN',
+        firstBrokenSequence: index,
+        reason: 'invalid-integrity-envelope',
+      };
+    }
+    if (sequence !== index || previous !== previousChecksum) {
+      return { status: 'BROKEN', firstBrokenSequence: index, reason: 'sequence-or-link-mismatch' };
+    }
+    const expected = checksumFor(normalizedEvents[index], sequence, previous, legacyPrefixLength);
+    if (checksum !== expected) {
+      return { status: 'BROKEN', firstBrokenSequence: index, reason: 'checksum-mismatch' };
+    }
+    previousChecksum = checksum;
+  }
+  if (records.length === 0) return { status: 'VALID' };
+  return legacyPrefixLength > 0 ? { status: 'VALID_WITH_LEGACY_PREFIX' } : { status: 'VALID' };
+}
+
+function buildIntegrityEntries(
+  events: AuditEvent[],
+  legacyPrefixLength: number,
+): Array<Record<string, unknown>> {
+  let previousChecksum = AUDIT_EVENT_STORE_GENESIS_PREVIOUS_CHECKSUM;
+  return events.map((event, sequence) => {
+    const entry = {
+      ...event,
+      sequence,
+      previousChecksum,
+      checksum: checksumFor(event, sequence, previousChecksum, legacyPrefixLength),
+    };
+    previousChecksum = entry.checksum;
+    return entry;
+  });
+}
+
+function checksumFor(
+  event: AuditEvent,
+  sequence: number,
+  previousChecksum: string,
+  legacyPrefixLength: number,
+): string {
+  return digest(
+    Buffer.from(
+      canonicalJson({
+        ...event,
+        integrityVersion: AUDIT_EVENT_INTEGRITY_VERSION,
+        legacyPrefixLength,
+        sequence,
+        previousChecksum,
+      }),
+      'utf8',
+    ),
+  );
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('unsupported non-finite value in canonical JSON');
+    return JSON.stringify(value);
+  }
+  if (typeof value !== 'object') throw new Error('unsupported value in canonical JSON');
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(',')}}`;
+}
+
+function digest(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
 }
 
 function normalizeAuditEvent(value: AuditEvent | unknown): AuditEvent {

--- a/ontoindex/src/core/ingestion/filesystem-walker.ts
+++ b/ontoindex/src/core/ingestion/filesystem-walker.ts
@@ -48,11 +48,29 @@ const toPosixPath = (value: string): string => value.replace(/\\/g, '/');
 /** Bytes read from the head of an extensionless file to inspect its shebang. */
 const SHEBANG_PROBE_BYTES = 256;
 
+/**
+ * A `.git` marker only bounds a nested repository when it is a real one: a
+ * worktree/submodule `.git` file, or a `.git` directory that holds `HEAD`.
+ * Empty or partial `.git` directories are stray leftovers, and excluding their
+ * parent would silently drop a first-party source tree from the index.
+ */
+async function isNestedGitMarker(markerPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(markerPath);
+    if (!stat.isDirectory()) return true;
+    await fs.stat(path.join(markerPath, 'HEAD'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function findNestedGitRoots(
   repoPath: string,
   ignoreFilter: Awaited<ReturnType<typeof createIgnoreFilter>>,
 ): Promise<Set<string>> {
   const roots = new Set<string>();
+  const ignoredMarkers: string[] = [];
   const markerIgnore = {
     ignored(p: Parameters<typeof ignoreFilter.ignored>[0]): boolean {
       const relative = toPosixPath(p.relative());
@@ -70,8 +88,21 @@ async function findNestedGitRoots(
     nodir: false,
     ignore: markerIgnore,
   })) {
-    const parent = path.posix.dirname(toPosixPath(String(entry)));
-    if (parent !== '.') roots.add(parent);
+    const relativeMarker = toPosixPath(String(entry));
+    const parent = path.posix.dirname(relativeMarker);
+    if (parent === '.') continue;
+    if (await isNestedGitMarker(path.join(repoPath, relativeMarker))) {
+      roots.add(parent);
+    } else {
+      ignoredMarkers.push(parent);
+    }
+  }
+  if (ignoredMarkers.length > 0 && isVerboseIngestionEnabled()) {
+    console.log(
+      `[scan] Ignored ${ignoredMarkers.length} stray .git marker(s) without HEAD: ${ignoredMarkers
+        .slice(0, 10)
+        .join(', ')}`,
+    );
   }
   return roots;
 }

--- a/ontoindex/src/core/lbug/pool-adapter.ts
+++ b/ontoindex/src/core/lbug/pool-adapter.ts
@@ -93,6 +93,14 @@ interface PoolEntry {
   waiters: PoolWaiter[];
   lastUsed: number;
   dbPath: string;
+  /**
+   * Identity of the database file this entry was opened against. `dbPath` is a
+   * stable path (`.ontoindex/current/lbug` is a symlink into a generation
+   * directory), so `ontoindex analyze` can swap the underlying file without
+   * changing the key. Cached handles would then read a replaced file and fail
+   * with "Corrupted wal file" until the process restarted.
+   */
+  dbIdentity: string | null;
   /** Set to true when the pool entry is closed — checkin will close orphaned connections */
   closed: boolean;
   /** Set while explicit close waits for active checkouts to finish */
@@ -508,6 +516,22 @@ function readBoundedIntEnv(name: string, fallback: number, min: number, max: num
 }
 
 /**
+ * Resolve the identity of the database file behind `dbPath`. The path is stable
+ * across reindexes, so identity is taken from the resolved real path plus
+ * inode/size/mtime. Returns null when the file cannot be inspected, in which
+ * case the caller keeps the existing handle rather than churning the pool.
+ */
+async function readDbIdentity(dbPath: string): Promise<string | null> {
+  try {
+    const realPath = await fs.realpath(dbPath);
+    const stat = await fs.stat(realPath);
+    return `${realPath}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Initialize (or reuse) a Database + connection pool for a specific repo.
  * Retries on lock errors (e.g., when `ontoindex analyze` is running).
  *
@@ -517,8 +541,15 @@ function readBoundedIntEnv(name: string, fallback: number, min: number, max: num
 export const initLbug = async (repoId: string, dbPath: string): Promise<void> => {
   const existing = pool.get(repoId);
   if (existing) {
-    existing.lastUsed = Date.now();
-    return;
+    const identity = await readDbIdentity(dbPath);
+    if (identity !== null && existing.dbIdentity !== null && identity !== existing.dbIdentity) {
+      // `ontoindex analyze` published a new generation behind the same path.
+      // Drop the stale handle so the next query opens the current database.
+      closeOne(repoId);
+    } else {
+      existing.lastUsed = Date.now();
+      return;
+    }
   }
 
   // Deduplicate concurrent init calls for the same repoId —
@@ -672,6 +703,7 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
     waiters: [],
     lastUsed: Date.now(),
     dbPath,
+    dbIdentity: await readDbIdentity(dbPath),
     closed: false,
     closing: false,
   });
@@ -737,6 +769,7 @@ export async function initLbugWithDb(
     waiters: [],
     lastUsed: Date.now(),
     dbPath,
+    dbIdentity: await readDbIdentity(dbPath),
     closed: false,
     closing: false,
   });

--- a/ontoindex/src/core/run-analyze.ts
+++ b/ontoindex/src/core/run-analyze.ts
@@ -38,6 +38,7 @@ import {
   createIndexGeneration,
   discardIndexGeneration,
   activateIndexGeneration,
+  publishIndexGenerationTransaction,
   type IndexGenerationPaths,
 } from '../storage/repo-manager.js';
 import type { DegradedFileGroupCount } from '../storage/repo-manager.js';
@@ -72,8 +73,20 @@ import { EMBEDDING_TEXT_VERSION } from './embeddings/embedding-pipeline.js';
 import {
   computeSourceManifest,
   manifestsMatch,
+  sourceManifestDigest,
   sourceInputsMatch,
 } from './indexing/source-manifest.js';
+import {
+  assertValidManagedAnalysisContext,
+  writeAnalysisPublicationReceipt,
+  type ManagedAnalysisContext,
+} from './analysis/analysis-publication-receipt.js';
+import {
+  beginManagedAnalysisPublication,
+  claimManagedAnalysisAnalyzer,
+  commitManagedAnalysisPublication,
+} from './analysis/analysis-coordinator.js';
+import { execFileText } from './process/exec-file.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -120,6 +133,8 @@ export interface AnalyzeOptions {
   profile?: PipelineProfile;
   /** Optional repository-relative roots to scan before ignore filtering. */
   includePaths?: string[];
+  /** Publication identity supplied only by the managed analysis runner. */
+  managedAnalysis?: ManagedAnalysisContext;
 }
 
 export type EmbeddingLifecycleMode = 'off' | 'preserve' | 'refresh';
@@ -161,6 +176,40 @@ export function resolveEmbeddingLifecycleMode(
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
 const EMBEDDING_NODE_LIMIT = 50_000;
+const MANAGED_GIT_STATUS_TIMEOUT_MS = 5_000;
+const MANAGED_GIT_STATUS_MAX_BUFFER = 1024 * 1024;
+
+async function verifyManagedAnalysisSource(
+  repoPath: string,
+  context: ManagedAnalysisContext,
+  boundary: 'before analysis' | 'before publication',
+): Promise<string> {
+  const currentCommit = getCurrentCommit(repoPath);
+  if (currentCommit !== context.targetHead) {
+    throw new Error(
+      `Managed analysis target HEAD does not match the current repository HEAD ${boundary}.`,
+    );
+  }
+
+  let status: string;
+  try {
+    status = await execFileText('git', ['status', '--porcelain=v1', '--untracked-files=all'], {
+      cwd: repoPath,
+      timeoutMs: MANAGED_GIT_STATUS_TIMEOUT_MS,
+      maxBuffer: MANAGED_GIT_STATUS_MAX_BUFFER,
+    });
+  } catch (error) {
+    throw new Error(
+      `Managed analysis could not verify a clean Git worktree ${boundary}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (status.trim().length > 0) {
+    throw new Error(`Managed analysis requires a clean Git worktree ${boundary}.`);
+  }
+  return currentCommit;
+}
 
 interface GraphDiffSnapshot {
   lastCommit: string;
@@ -800,7 +849,40 @@ export async function runFullAnalysis(
 
   const { storagePath, lbugPath: activeLbugPath } = getStoragePaths(repoPath);
   const repoHasGit = hasGitDir(repoPath);
-  if (repoHasGit) {
+  let currentCommit = repoHasGit ? getCurrentCommit(repoPath) : '';
+  if (options.managedAnalysis) {
+    assertValidManagedAnalysisContext(options.managedAnalysis);
+    if (options.force !== true) {
+      gcTelemetry?.stop();
+      throw new Error('Managed analysis requires force=true.');
+    }
+    if (!repoHasGit) {
+      gcTelemetry?.stop();
+      throw new Error('Managed analysis requires a Git worktree with a readable HEAD.');
+    }
+    if (
+      options.managedAnalysis.requestedCapabilities.embeddings &&
+      options.embeddings !== true &&
+      options.annNeighbors !== true
+    ) {
+      gcTelemetry?.stop();
+      throw new Error(
+        'Managed analysis requested embeddings, but no embedding analysis option was enabled.',
+      );
+    }
+    try {
+      await claimManagedAnalysisAnalyzer(repoPath, options.managedAnalysis);
+      currentCommit = await verifyManagedAnalysisSource(
+        repoPath,
+        options.managedAnalysis,
+        'before analysis',
+      );
+    } catch (error) {
+      gcTelemetry?.stop();
+      throw error;
+    }
+  }
+  if (repoHasGit && !options.managedAnalysis) {
     await addToGitignore(repoPath);
   }
   const includePaths = await normalizeRepositoryIncludePaths(repoPath, options.includePaths);
@@ -809,6 +891,16 @@ export async function runFullAnalysis(
     includePaths,
     pipelineProfile: requestedProfile,
   });
+  if (
+    options.managedAnalysis &&
+    sourceManifestDigest(inputManifest).toLowerCase() !==
+      options.managedAnalysis.sourceManifestDigest.toLowerCase()
+  ) {
+    gcTelemetry?.stop();
+    throw new Error(
+      'Managed analysis source manifest does not match the submission-time manifest digest.',
+    );
+  }
   const embeddingLifecycleMode = resolveEmbeddingLifecycleMode(options);
   const embeddingsEnabledForRun = embeddingLifecycleMode !== 'off';
   const annNeighborBuildRequested = options.annNeighbors === true;
@@ -819,7 +911,6 @@ export async function runFullAnalysis(
     log('Migrating from KuzuDB to LadybugDB — rebuilding index...');
   }
 
-  const currentCommit = repoHasGit ? getCurrentCommit(repoPath) : '';
   const existingMeta = await loadMeta(storagePath);
   let embeddingVectorIndexDigest = existingMeta?.embeddingVectorIndexDigest;
 
@@ -973,10 +1064,9 @@ export async function runFullAnalysis(
   });
   const lbugStart = Date.now();
 
-  const generationId = `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2)}`;
   let stagedGeneration: IndexGenerationPaths | null = await createIndexGeneration(
     storagePath,
-    generationId,
+    `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2)}`,
   );
   const generationStoragePath = stagedGeneration.generationPath;
   const lbugPath = stagedGeneration.lbugPath;
@@ -1201,6 +1291,14 @@ export async function runFullAnalysis(
     } catch {
       /* table may not exist if embeddings never ran */
     }
+    if (
+      options.managedAnalysis?.requestedCapabilities.embeddings === true &&
+      (embeddingSkipped || embeddingCount <= 0)
+    ) {
+      throw new Error(
+        'Managed analysis requested embeddings, but no embeddings were successfully published.',
+      );
+    }
 
     const indexedAt = new Date().toISOString();
     if (annNeighborBuildRequested) {
@@ -1259,6 +1357,20 @@ export async function runFullAnalysis(
             processes: pipelineResult.processResult !== undefined,
           },
         };
+    if (options.managedAnalysis) {
+      const publishedGraphCapabilities = pipelineCapabilityMetadata.capabilities;
+      const missingGraphCapability =
+        options.managedAnalysis.requestedCapabilities.graphCapabilities.find((capability) => {
+          if (capability === 'symbols') return publishedGraphCapabilities.symbols !== true;
+          if (capability === 'impact') return publishedGraphCapabilities.impact !== 'full';
+          return publishedGraphCapabilities.processes !== true;
+        });
+      if (missingGraphCapability) {
+        throw new Error(
+          `Managed analysis requested graph capability "${missingGraphCapability}", but it was not successfully published.`,
+        );
+      }
+    }
     const embeddingLifecycle: EmbeddingLifecycleSummary = !embeddingsEnabledForRun
       ? {
           mode: embeddingLifecycleMode,
@@ -1306,16 +1418,26 @@ export async function runFullAnalysis(
       pipelineProfile: requestedProfile,
       degradedPaths: [...degradedFiles.keys()],
     });
+    const finalManifestDigest = sourceManifestDigest(finalManifest);
     if (!sourceInputsMatch(inputManifest, finalManifest)) {
       throw new Error(
         'Source inputs changed during analysis; refusing to publish graph generation.',
+      );
+    }
+    if (
+      options.managedAnalysis &&
+      finalManifestDigest.toLowerCase() !==
+        options.managedAnalysis.sourceManifestDigest.toLowerCase()
+    ) {
+      throw new Error(
+        'Managed analysis final source manifest does not match the submission-time manifest digest.',
       );
     }
     const meta = {
       repoPath,
       lastCommit: currentCommit,
       indexedAt,
-      generationId,
+      generationId: stagedGeneration.generationId,
       sourceManifest: finalManifest,
       stats: {
         files: pipelineResult.totalFileCount,
@@ -1380,10 +1502,39 @@ export async function runFullAnalysis(
       currentCommit,
     );
     await saveMeta(generationStoragePath, meta);
-
-    await closeLbug();
-    await activateIndexGeneration(storagePath, stagedGeneration);
-    stagedGeneration = null;
+    if (options.managedAnalysis) {
+      const managedContext = options.managedAnalysis as ManagedAnalysisContext;
+      await beginManagedAnalysisPublication(repoPath, managedContext);
+      await verifyManagedAnalysisSource(repoPath, managedContext, 'before publication');
+      await writeAnalysisPublicationReceipt(generationStoragePath, {
+        version: 1,
+        jobId: managedContext.jobId,
+        repoPath: path.resolve(repoPath),
+        targetHead: managedContext.targetHead,
+        optionsDigest: managedContext.optionsDigest,
+        sourceIdentity: managedContext.sourceIdentity,
+        sourceManifestDigest: finalManifestDigest,
+        generationId: stagedGeneration.generationId,
+        requestedCapabilities: managedContext.requestedCapabilities,
+        analyzerContractVersion: finalManifest.analyzerContractVersion,
+        publishedAt: new Date().toISOString(),
+      });
+      await closeLbug();
+      const publishedGeneration = stagedGeneration;
+      await publishIndexGenerationTransaction(storagePath, publishedGeneration, (activation) =>
+        commitManagedAnalysisPublication(
+          repoPath,
+          managedContext,
+          activation.activeGeneration.generationId,
+          finalManifestDigest,
+        ),
+      );
+      stagedGeneration = null;
+    } else {
+      await closeLbug();
+      await activateIndexGeneration(storagePath, stagedGeneration);
+      stagedGeneration = null;
+    }
 
     // Forward the --name alias after the complete generation is active.
     const projectName = await registerRepo(repoPath, meta, {

--- a/ontoindex/src/core/run-analyze.ts
+++ b/ontoindex/src/core/run-analyze.ts
@@ -174,8 +174,19 @@ export function resolveEmbeddingLifecycleMode(
   return options?.force ? 'refresh' : 'preserve';
 }
 
-/** Threshold: auto-skip embeddings for repos with more nodes than this */
-const EMBEDDING_NODE_LIMIT = 50_000;
+/**
+ * Threshold: auto-skip embeddings for repos with more nodes than this.
+ * Override with ONTOINDEX_EMBEDDING_NODE_LIMIT for large first-party repos
+ * that would otherwise never populate embeddings, leaving semantic search
+ * permanently empty. A non-positive value disables the cap.
+ */
+const DEFAULT_EMBEDDING_NODE_LIMIT = 50_000;
+
+function embeddingNodeLimit(): number {
+  const configured = Number.parseInt(process.env.ONTOINDEX_EMBEDDING_NODE_LIMIT ?? '', 10);
+  if (!Number.isFinite(configured)) return DEFAULT_EMBEDDING_NODE_LIMIT;
+  return configured <= 0 ? Number.POSITIVE_INFINITY : configured;
+}
 const MANAGED_GIT_STATUS_TIMEOUT_MS = 5_000;
 const MANAGED_GIT_STATUS_MAX_BUFFER = 1024 * 1024;
 
@@ -1208,11 +1219,13 @@ export async function runFullAnalysis(
     if (embeddingsEnabledForRun) {
       const embeddableNodeCount = await countEmbeddableGraphNodes();
       const embeddingLimitCount = embeddableNodeCount ?? stats.nodes;
-      if (embeddingLimitCount <= EMBEDDING_NODE_LIMIT) {
+      const nodeLimit = embeddingNodeLimit();
+      if (embeddingLimitCount <= nodeLimit) {
         embeddingSkipped = false;
       } else {
         log(
-          `Skipping embeddings for ${embeddingLimitCount} embeddable nodes (limit ${EMBEDDING_NODE_LIMIT}).`,
+          `Skipping embeddings for ${embeddingLimitCount} embeddable nodes (limit ${nodeLimit}). ` +
+            `Set ONTOINDEX_EMBEDDING_NODE_LIMIT to raise or disable this cap.`,
         );
       }
     }

--- a/ontoindex/src/core/runtime/runtime-health.ts
+++ b/ontoindex/src/core/runtime/runtime-health.ts
@@ -100,7 +100,9 @@ export async function readRuntimeHealth(
   const storagePath = options.storagePath ?? getStoragePaths(repoPath).storagePath;
   const repoLabel = options.repoLabel ?? path.basename(repoPath);
   const warnings: string[] = [];
-  const meta = options.meta ?? (await loadMeta(storagePath));
+  const meta = Object.hasOwn(options, 'meta')
+    ? (options.meta ?? null)
+    : await loadMeta(storagePath);
   const currentCommit = normalizeCommit(getCurrentCommit(repoPath));
   const dirtyWorktree = await readDirtyWorktree(repoPath, warnings);
   const analyzeLock = await readAnalyzeLock(storagePath, warnings);

--- a/ontoindex/src/mcp/shared/target-context.ts
+++ b/ontoindex/src/mcp/shared/target-context.ts
@@ -11,8 +11,14 @@ import {
   type GitPorcelainWorkspaceSummary,
 } from '../../core/audit-lifecycle/freshness.js';
 import { loadIgnoreRules, shouldIgnorePath } from '../../config/ignore-service.js';
-import { readRegistry, type RegistryEntry } from '../../storage/repo-manager.js';
-import { loadMeta, resolveActiveIndexGeneration } from '../../storage/repo-manager.js';
+import {
+  loadMeta,
+  readActiveGenerationMeta,
+  readRegistry,
+  resolveActiveIndexGeneration,
+  type ActiveGenerationMetaPair,
+  type RegistryEntry,
+} from '../../storage/repo-manager.js';
 import {
   computeSourceManifest,
   manifestsMatch,
@@ -63,6 +69,7 @@ export interface TargetContextLspReadiness extends TargetContextReadiness {
 
 export interface TargetContextEmbeddingsReadiness extends TargetContextReadiness {
   count?: number;
+  modelHash?: string;
 }
 
 export interface TargetContextSidecarReadiness extends TargetContextReadiness {
@@ -145,6 +152,7 @@ export interface ResolveTargetContextDeps {
   loadMeta?: typeof loadMeta;
   computeSourceManifest?: typeof computeSourceManifest;
   resolveActiveIndexGeneration?: typeof resolveActiveIndexGeneration;
+  readActiveGenerationMeta?: typeof readActiveGenerationMeta;
 }
 
 export async function resolveTargetContext(
@@ -291,21 +299,45 @@ export async function resolveTargetContext(
   const workspaceSummary = summarizeGitPorcelainStatus(statusOutput);
   const dirtyWorktree = workspaceSummary !== null ? workspaceSummary.dirtyFileCount > 0 : null;
   const dirtyFileCount = workspaceSummary?.dirtyFileCount ?? null;
-  const indexedHead = entry.lastCommit || undefined;
+  const generationMeta = await readGenerationMetaPair(entry.storagePath, deps);
+  const activeMeta = generationMeta.meta;
+  const activeGeneration = generationMeta.activeGeneration;
+  const trustedIndexMeta = generationMeta.authority !== 'untrusted';
+  if (generationMeta.authority === 'untrusted') {
+    warnings.push(generationMetadataWarning(generationMeta, entry.lastCommit));
+  }
+  const indexedHead =
+    (trustedIndexMeta ? activeMeta?.lastCommit : undefined) || entry.lastCommit || undefined;
+  if (
+    trustedIndexMeta &&
+    activeMeta?.lastCommit &&
+    entry.lastCommit &&
+    activeMeta.lastCommit !== entry.lastCommit
+  ) {
+    warnings.push(
+      `Registry commit ${entry.lastCommit} lags trusted index metadata ${activeMeta.lastCommit}; using trusted metadata as indexed-head authority.`,
+    );
+  }
   const graphAuthority = options.verifyGraphAuthority
-    ? await resolveGraphAuthority(
-        repoPath,
-        await (deps.loadMeta ?? loadMeta)(entry.storagePath),
-        deps.computeSourceManifest ?? computeSourceManifest,
-        (
-          await (deps.resolveActiveIndexGeneration ?? resolveActiveIndexGeneration)(
-            entry.storagePath,
-          )
-        )?.generationId,
-        options.requiredGraphCapabilities ?? [],
-        targetHead,
-        currentHead,
-      )
+    ? generationMeta.authority === 'untrusted'
+      ? {
+          state: 'degraded' as const,
+          reason:
+            generationMeta.reason === 'active-generation-metadata-mismatch'
+              ? 'active graph generation does not match metadata generation'
+              : 'active generation metadata authority is untrusted',
+          ...(activeGeneration ? { generationId: activeGeneration.generationId } : {}),
+          coverage: 'unknown' as const,
+        }
+      : await resolveGraphAuthority(
+          repoPath,
+          activeMeta,
+          deps.computeSourceManifest ?? computeSourceManifest,
+          activeGeneration?.generationId,
+          options.requiredGraphCapabilities ?? [],
+          targetHead,
+          currentHead,
+        )
     : undefined;
   const headChangedSinceIndex = !!currentHead && !!indexedHead && currentHead !== indexedHead;
   const changedSinceIndex =
@@ -366,12 +398,55 @@ export async function resolveTargetContext(
     scopeConfidence: confidence.value,
     scopeConfidenceReason: confidence.reason,
     ...(confidence.repairCommand ? { repairCommand: confidence.repairCommand } : {}),
-    embeddings: resolveEmbeddingsReadiness(entry, options.readiness?.embeddingsCount),
+    embeddings: resolveEmbeddingsReadiness(
+      entry,
+      options.readiness?.embeddingsCount,
+      trustedIndexMeta ? activeMeta?.model_hash : undefined,
+    ),
     lsp: resolveLspReadiness(options.readiness?.lspAvailable),
     sidecar: await resolveSidecarReadiness(entry, options.checkSidecar === true, deps, warnings),
     policy: { status: 'unknown', reason: 'policy-profile-probe-not-configured' },
     warnings,
   };
+}
+
+async function readGenerationMetaPair(
+  storagePath: string,
+  deps: ResolveTargetContextDeps,
+): Promise<ActiveGenerationMetaPair> {
+  if (deps.readActiveGenerationMeta) return deps.readActiveGenerationMeta(storagePath);
+  if (!deps.loadMeta && !deps.resolveActiveIndexGeneration) {
+    return readActiveGenerationMeta(storagePath);
+  }
+
+  const meta = await (deps.loadMeta ?? loadMeta)(storagePath);
+  const activeGeneration = await (
+    deps.resolveActiveIndexGeneration ?? resolveActiveIndexGeneration
+  )(storagePath);
+  if (activeGeneration && meta?.generationId === activeGeneration.generationId) {
+    return { activeGeneration, meta, authority: 'active-generation' };
+  }
+  if (!activeGeneration && meta && meta.generationId === undefined) {
+    return { activeGeneration: null, meta, authority: 'legacy-root' };
+  }
+  return {
+    activeGeneration,
+    meta: null,
+    authority: 'untrusted',
+    reason:
+      !activeGeneration && meta?.generationId
+        ? 'generation-tagged-root-metadata-without-active-generation'
+        : meta
+          ? 'active-generation-metadata-mismatch'
+          : 'active-generation-metadata-unavailable',
+  };
+}
+
+function generationMetadataWarning(pair: ActiveGenerationMetaPair, registryCommit: string): string {
+  const fallback = registryCommit
+    ? `using registry commit ${registryCommit} as a conservative indexed-head fallback`
+    : 'no trusted indexed-head fallback is available';
+  return `Active generation metadata authority is untrusted (${pair.reason ?? 'unknown reason'}); ${fallback}. Generation metadata is excluded from commit and graph claims.`;
 }
 
 async function resolveGraphAuthority(
@@ -883,12 +958,29 @@ function buildAmbiguousRepoAction(
 function resolveEmbeddingsReadiness(
   entry: RegistryEntry,
   overrideCount: number | undefined,
+  modelHash: string | undefined,
 ): TargetContextEmbeddingsReadiness {
   const count = overrideCount ?? entry.stats?.embeddings;
-  if (count === undefined) return { status: 'unknown', reason: 'embedding-stats-unavailable' };
+  const normalizedModelHash = modelHash?.trim() || undefined;
+  if (count === undefined) {
+    return {
+      status: 'unknown',
+      reason: 'embedding-stats-unavailable',
+      ...(normalizedModelHash ? { modelHash: normalizedModelHash } : {}),
+    };
+  }
   return count > 0
-    ? { status: 'available', count }
-    : { status: 'unavailable', count, reason: 'embeddings-not-populated' };
+    ? {
+        status: 'available',
+        count,
+        ...(normalizedModelHash ? { modelHash: normalizedModelHash } : {}),
+      }
+    : {
+        status: 'unavailable',
+        count,
+        reason: 'embeddings-not-populated',
+        ...(normalizedModelHash ? { modelHash: normalizedModelHash } : {}),
+      };
 }
 
 function resolveLspReadiness(

--- a/ontoindex/src/mcp/super/analyze-job.ts
+++ b/ontoindex/src/mcp/super/analyze-job.ts
@@ -6,6 +6,7 @@ import {
   type AnalysisJobRecord,
 } from '../../core/analysis/analysis-coordinator.js';
 import {
+  isValidSourceIdentity,
   readAnalysisPublicationReceipt,
   type AnalysisPublicationReceipt,
 } from '../../core/analysis/analysis-publication-receipt.js';
@@ -59,11 +60,11 @@ async function observeRecovery(
   job: AnalysisJobRecord,
   resolvedRepoPath: string,
 ): Promise<AnalysisRecovery> {
-  if (job.sourceIdentity !== `commit:${job.targetHead}`) {
+  if (!isValidSourceIdentity(job.sourceIdentity, job.targetHead, job.sourceManifestDigest)) {
     return terminalUnconfirmed(
       job,
       'JOB_SOURCE_IDENTITY_MISMATCH',
-      'The analysis job record does not identify the exact clean commit requested for analysis.',
+      'The analysis job record does not identify the exact commit or working-tree source requested for analysis.',
     );
   }
   if (!hasRequestedCapabilities(job.requestedCapabilities)) {

--- a/ontoindex/src/mcp/super/analyze-job.ts
+++ b/ontoindex/src/mcp/super/analyze-job.ts
@@ -1,10 +1,36 @@
-import { cancelAnalysisJob, getAnalysisJob } from '../../core/analysis/analysis-coordinator.js';
-import { gnEnsureFresh } from './ensure-fresh.js';
+import path from 'node:path';
+
+import {
+  cancelAnalysisJob,
+  getAnalysisJob,
+  type AnalysisJobRecord,
+} from '../../core/analysis/analysis-coordinator.js';
+import {
+  readAnalysisPublicationReceipt,
+  type AnalysisPublicationReceipt,
+} from '../../core/analysis/analysis-publication-receipt.js';
+import { resolveActiveIndexGeneration } from '../../storage/repo-manager.js';
+import { resolveTargetContext, type TargetContext } from '../shared/target-context.js';
+import { gnEnsureFresh, type EnsureFreshReport } from './ensure-fresh.js';
 
 export interface AnalyzeJobParams {
   repo?: string;
   jobId: string;
   action?: 'status' | 'cancel';
+}
+
+export type AnalysisRecoveryDisposition =
+  | 'REFRESH_RUNNING'
+  | 'REFRESHED'
+  | 'FAILED'
+  | 'FRESHNESS_UNCONFIRMED';
+
+export interface AnalysisRecovery {
+  disposition: AnalysisRecoveryDisposition;
+  reasonCode: string;
+  message: string;
+  receipt?: AnalysisPublicationReceipt;
+  postCheck?: EnsureFreshReport;
 }
 
 export async function gnAnalyzeJob(repoId: string, params: AnalyzeJobParams): Promise<unknown> {
@@ -16,10 +42,485 @@ export async function gnAnalyzeJob(repoId: string, params: AnalyzeJobParams): Pr
   }
   const job = await getAnalysisJob(freshness.repoPath, params.jobId);
   return job
-    ? { job, repoLabel: freshness.repoLabel, repoPath: freshness.repoPath }
+    ? {
+        job,
+        repoLabel: freshness.repoLabel,
+        repoPath: freshness.repoPath,
+        recovery: await observeRecovery(job, freshness.repoPath),
+      }
     : {
         error: 'Analysis job not found.',
         repoLabel: freshness.repoLabel,
         repoPath: freshness.repoPath,
       };
+}
+
+async function observeRecovery(
+  job: AnalysisJobRecord,
+  resolvedRepoPath: string,
+): Promise<AnalysisRecovery> {
+  if (job.sourceIdentity !== `commit:${job.targetHead}`) {
+    return terminalUnconfirmed(
+      job,
+      'JOB_SOURCE_IDENTITY_MISMATCH',
+      'The analysis job record does not identify the exact clean commit requested for analysis.',
+    );
+  }
+  if (!hasRequestedCapabilities(job.requestedCapabilities)) {
+    return terminalUnconfirmed(
+      job,
+      'JOB_CAPABILITIES_UNAVAILABLE',
+      'The analysis job record does not contain a valid requested-capabilities identity.',
+    );
+  }
+  if (!isSha256(job.sourceManifestDigest)) {
+    return terminalUnconfirmed(
+      job,
+      'JOB_MANIFEST_IDENTITY_UNAVAILABLE',
+      'The analysis job record does not contain a valid source-manifest identity.',
+    );
+  }
+  if (job.status === 'queued' || job.status === 'running') {
+    return recovery(
+      'REFRESH_RUNNING',
+      'ANALYSIS_IN_PROGRESS',
+      `Analysis job ${job.id} is ${job.status}.`,
+    );
+  }
+  if (job.status === 'cancelled') {
+    return recovery('FAILED', 'CANCELLED', `Analysis job ${job.id} was cancelled.`);
+  }
+  if (job.status === 'failed') {
+    return recovery(
+      'FAILED',
+      'ANALYSIS_FAILED',
+      `Analysis job ${job.id} failed${
+        typeof job.exitCode === 'number' ? ` with exit code ${job.exitCode}` : ''
+      }.`,
+    );
+  }
+  const activeGeneration = await resolveActiveIndexGeneration(
+    path.join(resolvedRepoPath, '.ontoindex'),
+  );
+  if (!activeGeneration) {
+    return terminalUnconfirmed(
+      job,
+      'ACTIVE_GENERATION_UNAVAILABLE',
+      'The active index generation could not be resolved.',
+    );
+  }
+
+  const receipt = await readAnalysisPublicationReceipt(activeGeneration.generationPath, job.id);
+  if (!receipt) {
+    return terminalUnconfirmed(
+      job,
+      'PUBLICATION_RECEIPT_UNAVAILABLE',
+      'No valid publication receipt for this job exists in the active generation.',
+    );
+  }
+
+  const receiptMismatch = validateReceipt(
+    job,
+    resolvedRepoPath,
+    activeGeneration.generationId,
+    receipt,
+  );
+  if (receiptMismatch) {
+    return terminalUnconfirmed(job, receiptMismatch.reasonCode, receiptMismatch.message, receipt);
+  }
+
+  let postCheck: EnsureFreshReport;
+  let targetContext: TargetContext;
+  try {
+    postCheck = await gnEnsureFresh(resolvedRepoPath, {
+      repo: resolvedRepoPath,
+      withEmbeddings: job.requestedCapabilities.embeddings,
+      requiredGraphCapabilities: job.requestedCapabilities.graphCapabilities,
+    });
+    targetContext = await resolveTargetContext({
+      repo: resolvedRepoPath,
+      verifyGraphAuthority: true,
+      requiredGraphCapabilities: job.requestedCapabilities.graphCapabilities,
+    });
+  } catch {
+    return terminalUnconfirmed(
+      job,
+      'POSTCHECK_UNAVAILABLE',
+      'The final freshness and graph-authority post-check could not be completed.',
+      receipt,
+    );
+  }
+  const postCheckFailure = validatePostCheck(job, receipt, postCheck, targetContext);
+  if (postCheckFailure) {
+    return terminalUnconfirmed(
+      job,
+      postCheckFailure.reasonCode,
+      postCheckFailure.message,
+      receipt,
+      postCheck,
+    );
+  }
+
+  let finalPostCheck: EnsureFreshReport;
+  let finalTargetContext: TargetContext;
+  let generationAfterFirstPostCheck;
+  try {
+    generationAfterFirstPostCheck = await resolveActiveIndexGeneration(
+      path.join(resolvedRepoPath, '.ontoindex'),
+    );
+    finalPostCheck = await gnEnsureFresh(resolvedRepoPath, {
+      repo: resolvedRepoPath,
+      withEmbeddings: job.requestedCapabilities.embeddings,
+      requiredGraphCapabilities: job.requestedCapabilities.graphCapabilities,
+    });
+    finalTargetContext = await resolveTargetContext({
+      repo: resolvedRepoPath,
+      verifyGraphAuthority: true,
+      requiredGraphCapabilities: job.requestedCapabilities.graphCapabilities,
+    });
+  } catch {
+    return terminalUnconfirmed(
+      job,
+      'FINAL_POSTCHECK_UNAVAILABLE',
+      'The final stability post-check could not be completed.',
+      receipt,
+      postCheck,
+    );
+  }
+  if (
+    !generationAfterFirstPostCheck ||
+    generationAfterFirstPostCheck.generationId !== receipt.generationId
+  ) {
+    return terminalUnconfirmed(
+      job,
+      'ACTIVE_GENERATION_CHANGED',
+      'The active index generation changed while the job result was being verified.',
+      receipt,
+      postCheck,
+    );
+  }
+  const finalPostCheckFailure = validatePostCheck(job, receipt, finalPostCheck, finalTargetContext);
+  if (finalPostCheckFailure) {
+    return terminalUnconfirmed(
+      job,
+      finalPostCheckFailure.reasonCode,
+      finalPostCheckFailure.message,
+      receipt,
+      finalPostCheck,
+    );
+  }
+
+  let generationAfterFinalPostCheck;
+  try {
+    generationAfterFinalPostCheck = await resolveActiveIndexGeneration(
+      path.join(resolvedRepoPath, '.ontoindex'),
+    );
+  } catch {
+    return terminalUnconfirmed(
+      job,
+      'FINAL_GENERATION_CHECK_UNAVAILABLE',
+      'The active index generation could not be checked after final verification.',
+      receipt,
+      finalPostCheck,
+    );
+  }
+  if (
+    !generationAfterFinalPostCheck ||
+    generationAfterFinalPostCheck.generationId !== receipt.generationId
+  ) {
+    return terminalUnconfirmed(
+      job,
+      'ACTIVE_GENERATION_CHANGED',
+      'The active index generation changed while the job result was being verified.',
+      receipt,
+      finalPostCheck,
+    );
+  }
+
+  let terminalPostCheck: EnsureFreshReport;
+  let terminalTargetContext: TargetContext;
+  try {
+    terminalPostCheck = await gnEnsureFresh(resolvedRepoPath, {
+      repo: resolvedRepoPath,
+      withEmbeddings: job.requestedCapabilities.embeddings,
+      requiredGraphCapabilities: job.requestedCapabilities.graphCapabilities,
+    });
+    terminalTargetContext = await resolveTargetContext({
+      repo: resolvedRepoPath,
+      verifyGraphAuthority: true,
+      requiredGraphCapabilities: job.requestedCapabilities.graphCapabilities,
+    });
+  } catch {
+    return terminalUnconfirmed(
+      job,
+      'TERMINAL_POSTCHECK_UNAVAILABLE',
+      'The terminal freshness and graph-authority observation could not be completed.',
+      receipt,
+      finalPostCheck,
+    );
+  }
+  const terminalPostCheckFailure = validatePostCheck(
+    job,
+    receipt,
+    terminalPostCheck,
+    terminalTargetContext,
+  );
+  if (terminalPostCheckFailure) {
+    return terminalUnconfirmed(
+      job,
+      terminalPostCheckFailure.reasonCode,
+      terminalPostCheckFailure.message,
+      receipt,
+      terminalPostCheck,
+    );
+  }
+
+  return {
+    disposition: 'REFRESHED',
+    reasonCode: 'PUBLICATION_VERIFIED',
+    message:
+      'The publication receipt and current index postconditions prove that the requested refresh succeeded.',
+    receipt,
+    postCheck: terminalPostCheck,
+  };
+}
+
+function validateReceipt(
+  job: AnalysisJobRecord,
+  resolvedRepoPath: string,
+  activeGenerationId: string,
+  receipt: AnalysisPublicationReceipt,
+): { reasonCode: string; message: string } | null {
+  if (receipt.jobId !== job.id) {
+    return mismatch('RECEIPT_JOB_MISMATCH', 'The publication receipt belongs to a different job.');
+  }
+  if (path.resolve(receipt.repoPath) !== path.resolve(resolvedRepoPath)) {
+    return mismatch(
+      'RECEIPT_REPO_MISMATCH',
+      'The publication receipt belongs to a different repository.',
+    );
+  }
+  if (path.resolve(job.repoPath) !== path.resolve(resolvedRepoPath)) {
+    return mismatch(
+      'JOB_REPO_MISMATCH',
+      'The analysis job belongs to a different repository than the resolved target.',
+    );
+  }
+  if (receipt.targetHead !== job.targetHead) {
+    return mismatch(
+      'RECEIPT_TARGET_MISMATCH',
+      'The publication receipt target does not match the job target.',
+    );
+  }
+  if (receipt.sourceIdentity !== job.sourceIdentity) {
+    return mismatch(
+      'RECEIPT_SOURCE_IDENTITY_MISMATCH',
+      'The publication receipt source identity does not match the job source identity.',
+    );
+  }
+  if (receipt.optionsDigest !== job.optionsDigest) {
+    return mismatch(
+      'RECEIPT_OPTIONS_MISMATCH',
+      'The publication receipt options do not match the job request.',
+    );
+  }
+  if (!sameCapabilities(receipt.requestedCapabilities, job.requestedCapabilities)) {
+    return mismatch(
+      'RECEIPT_CAPABILITIES_MISMATCH',
+      'The publication receipt capabilities do not match the job request.',
+    );
+  }
+  if (receipt.generationId !== activeGenerationId) {
+    return mismatch(
+      'RECEIPT_GENERATION_MISMATCH',
+      'The publication receipt does not belong to the active index generation.',
+    );
+  }
+  if (job.generationId && job.generationId !== receipt.generationId) {
+    return mismatch(
+      'JOB_GENERATION_MISMATCH',
+      'The terminal job record and publication receipt identify different generations.',
+    );
+  }
+  if (job.sourceManifestDigest.toLowerCase() !== receipt.sourceManifestDigest.toLowerCase()) {
+    return mismatch(
+      'RECEIPT_MANIFEST_MISMATCH',
+      'The publication receipt source manifest does not match the terminal job record.',
+    );
+  }
+  return null;
+}
+
+function validatePostCheck(
+  job: AnalysisJobRecord,
+  receipt: AnalysisPublicationReceipt,
+  postCheck: EnsureFreshReport,
+  targetContext: TargetContext,
+): { reasonCode: string; message: string } | null {
+  if (
+    postCheck.indexedCommit !== job.targetHead ||
+    postCheck.headCommit !== job.targetHead ||
+    postCheck.preCheck.indexedCommit !== job.targetHead ||
+    postCheck.preCheck.currentCommit !== job.targetHead ||
+    postCheck.isStale !== false ||
+    postCheck.preCheck.isStale !== false
+  ) {
+    return mismatch(
+      'POSTCHECK_TARGET_MISMATCH',
+      'The current checkout and indexed commit do not both match the job target.',
+    );
+  }
+  if (postCheck.dirtyFileCount !== 0) {
+    return mismatch(
+      'POSTCHECK_WORKTREE_UNCONFIRMED',
+      'The final freshness post-check did not prove a clean worktree.',
+    );
+  }
+  if (
+    targetContext.status !== 'ok' ||
+    targetContext.repoPath === undefined ||
+    path.resolve(targetContext.repoPath) !== path.resolve(job.repoPath) ||
+    targetContext.targetHead !== job.targetHead ||
+    targetContext.currentHead !== job.targetHead ||
+    targetContext.indexedHead !== job.targetHead
+  ) {
+    return mismatch(
+      'TARGET_CONTEXT_MISMATCH',
+      'The authoritative target context does not match the job target and repository.',
+    );
+  }
+  if (targetContext.dirtyWorktree !== false) {
+    return mismatch(
+      'TARGET_CONTEXT_WORKTREE_UNCONFIRMED',
+      'The authoritative target context did not prove a clean worktree.',
+    );
+  }
+  if (targetContext.snapshotMode !== 'committed-head') {
+    return mismatch(
+      'TARGET_CONTEXT_SNAPSHOT_MISMATCH',
+      'The authoritative target context is not a committed-HEAD snapshot.',
+    );
+  }
+  if (targetContext.changedSinceIndex !== false) {
+    return mismatch(
+      'TARGET_CONTEXT_INDEX_DRIFT',
+      'The authoritative target context reports changes since the published index.',
+    );
+  }
+  if (
+    targetContext.graphAuthority?.state !== 'authoritative' ||
+    targetContext.graphAuthority.generationId !== receipt.generationId ||
+    targetContext.graphAuthority.manifestDigest?.toLowerCase() !==
+      receipt.sourceManifestDigest.toLowerCase()
+  ) {
+    return mismatch(
+      'GRAPH_AUTHORITY_UNCONFIRMED',
+      'The active graph generation is not authoritative for the published receipt.',
+    );
+  }
+  if (job.requestedCapabilities.embeddings) {
+    const requestedModelHash = job.requestedCapabilities.embeddingModelHash;
+    if (
+      !requestedModelHash ||
+      postCheck.embeddingsStatus.status !== 'ok' ||
+      postCheck.embeddingsStatus.actualModelHash !== requestedModelHash ||
+      targetContext.embeddings.status !== 'available' ||
+      targetContext.embeddings.modelHash !== requestedModelHash
+    ) {
+      return mismatch(
+        'EMBEDDINGS_UNCONFIRMED',
+        'The job requested embeddings, but the active generation does not prove the requested embedding model identity.',
+      );
+    }
+  }
+  return null;
+}
+
+function sameCapabilities(
+  left: AnalysisPublicationReceipt['requestedCapabilities'],
+  right: unknown,
+): boolean {
+  return (
+    hasRequestedCapabilities(right) &&
+    left.version === right.version &&
+    left.graph === right.graph &&
+    left.graphCapabilities.length === right.graphCapabilities.length &&
+    left.graphCapabilities.every(
+      (capability, index) => capability === right.graphCapabilities[index],
+    ) &&
+    left.embeddings === right.embeddings &&
+    left.embeddingModelHash === right.embeddingModelHash
+  );
+}
+
+function hasRequestedCapabilities(
+  value: unknown,
+): value is AnalysisJobRecord['requestedCapabilities'] {
+  if (typeof value !== 'object' || value === null) return false;
+  const capabilities = value as {
+    version?: unknown;
+    graph?: unknown;
+    graphCapabilities?: unknown;
+    embeddings?: unknown;
+    embeddingModelHash?: unknown;
+  };
+  if (
+    capabilities.version !== 1 ||
+    capabilities.graph !== true ||
+    !Array.isArray(capabilities.graphCapabilities) ||
+    capabilities.graphCapabilities.length === 0 ||
+    typeof capabilities.embeddings !== 'boolean'
+  ) {
+    return false;
+  }
+  const graphCapabilities = capabilities.graphCapabilities;
+  if (
+    graphCapabilities.some(
+      (capability) =>
+        capability !== 'symbols' && capability !== 'impact' && capability !== 'processes',
+    ) ||
+    graphCapabilities.some((capability, index) =>
+      index > 0
+        ? String(graphCapabilities[index - 1]).localeCompare(String(capability)) >= 0
+        : false,
+    )
+  ) {
+    return false;
+  }
+  return capabilities.embeddings
+    ? typeof capabilities.embeddingModelHash === 'string' &&
+        capabilities.embeddingModelHash.trim().length > 0
+    : capabilities.embeddingModelHash === null;
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-fA-F]{64}$/.test(value);
+}
+
+function mismatch(reasonCode: string, message: string): { reasonCode: string; message: string } {
+  return { reasonCode, message };
+}
+
+function terminalUnconfirmed(
+  job: AnalysisJobRecord,
+  reasonCode: string,
+  message: string,
+  receipt?: AnalysisPublicationReceipt,
+  postCheck?: EnsureFreshReport,
+): AnalysisRecovery {
+  return {
+    disposition: job.status === 'failed' ? 'FAILED' : 'FRESHNESS_UNCONFIRMED',
+    reasonCode,
+    message,
+    ...(receipt ? { receipt } : {}),
+    ...(postCheck ? { postCheck } : {}),
+  };
+}
+
+function recovery(
+  disposition: AnalysisRecoveryDisposition,
+  reasonCode: string,
+  message: string,
+): AnalysisRecovery {
+  return { disposition, reasonCode, message };
 }

--- a/ontoindex/src/mcp/super/audit-advanced.ts
+++ b/ontoindex/src/mcp/super/audit-advanced.ts
@@ -5,6 +5,8 @@ import {
   evaluateAuditScopeGuard,
   generateAuditDispatchPrompt,
   LocalAuditEventStore,
+  type AuditEventStoreIntegrity,
+  type AuditEventStoreState,
   type AuditImplementationBundle,
   type AuditSessionBundle,
   type AuditSessionEvidence,
@@ -104,6 +106,7 @@ export async function gnDispatchPrompt(
 ): Promise<Record<string, unknown>> {
   const repo = await resolveAuditRepoHandle(repoId, params.repo);
   const { sessionId, projection, state } = await loadAuditProjection(repo.repoPath, params);
+  assertAuditChainUsableForDispatch(state);
   const session = requireSession(projection.sessions, sessionId);
   const bundles = loadImplementationBundles(state.events, projection, sessionId, params.strategy);
   const selected = selectBundle(bundles, params.bundleId);
@@ -154,7 +157,8 @@ export async function gnDispatchPrompt(
       promptChars: result.prompt.length,
       truncated: result.prompt.length > maxPromptChars,
     },
-    warnings: [],
+    integrity: state.integrity,
+    warnings: integrityWarnings(state.integrity),
     skipReasons: [],
   };
 }
@@ -288,8 +292,68 @@ async function loadAuditProjection(
 ) {
   const sessionId = params.sessionId ?? params.session;
   if (!sessionId) throw new Error('session is required');
-  const state = await new LocalAuditEventStore(repoPath).load();
+  let state: AuditEventStoreState;
+  try {
+    state = await new LocalAuditEventStore(repoPath).load();
+  } catch (error) {
+    throw auditChainError('audit event store load/parse failed', error);
+  }
   return { sessionId, state, projection: buildAuditProjection(state.events) };
+}
+
+function assertAuditChainUsableForDispatch(state: AuditEventStoreState): void {
+  if (!isDispatchableIntegrity(state.integrity)) {
+    throw auditChainError('audit event chain is not trustworthy', state.integrity);
+  }
+}
+
+// Dispatch is a trust decision: only a fully verified chain qualifies. Legacy
+// history is never migrated in place, so no partially-trusted state is
+// dispatchable.
+export function isDispatchableIntegrity(integrity: AuditEventStoreIntegrity | undefined): boolean {
+  return integrity?.status === 'VALID';
+}
+
+export function auditChainError(
+  message: string,
+  detail: unknown,
+): Error & {
+  code: 'ERR_AUDIT_CHAIN_BROKEN';
+  firstBrokenSequence?: number;
+  reason: string;
+} {
+  const error = new Error(message) as Error & {
+    code: 'ERR_AUDIT_CHAIN_BROKEN';
+    firstBrokenSequence?: number;
+    reason: string;
+  };
+  error.code = 'ERR_AUDIT_CHAIN_BROKEN';
+  if (isIntegrity(detail)) {
+    error.firstBrokenSequence = detail.firstBrokenSequence;
+    error.reason = detail.reason ?? 'unknown-integrity-failure';
+  } else {
+    error.reason = detail instanceof Error ? detail.message : 'audit-event-store-load-failure';
+  }
+  return error;
+}
+
+export function integrityWarnings(integrity: AuditEventStoreIntegrity | undefined): string[] {
+  if (integrity?.status === 'LEGACY_UNVERIFIED') {
+    return ['Audit event chain uses a legacy unverified prefix.'];
+  }
+  if (integrity?.status === 'VALID_WITH_LEGACY_PREFIX') {
+    return ['Audit event chain has a valid suffix with a legacy unverified prefix.'];
+  }
+  return [];
+}
+
+function isIntegrity(value: unknown): value is AuditEventStoreIntegrity {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'status' in value &&
+    typeof value.status === 'string'
+  );
 }
 
 function requireSession(

--- a/ontoindex/src/mcp/super/audit-session-tools.ts
+++ b/ontoindex/src/mcp/super/audit-session-tools.ts
@@ -17,7 +17,14 @@ import {
   type StaleAuditSessionLockResult,
 } from '../../core/audit-lifecycle/index.js';
 import { execFileText } from '../../core/process/exec-file.js';
-import { gnAuditDedupe, gnDispatchPrompt, gnScopeGuard } from './audit-advanced.js';
+import {
+  auditChainError,
+  gnAuditDedupe,
+  gnDispatchPrompt,
+  gnScopeGuard,
+  integrityWarnings,
+  isDispatchableIntegrity,
+} from './audit-advanced.js';
 import { runAuditBundle } from './audit-bundle.js';
 import { resolveAuditRepoHandle, runAuditIngest } from './audit-ingest.js';
 import { runAuditVerify } from './audit-verify.js';
@@ -202,9 +209,10 @@ export async function gnAuditDiff(
   params: AuditDiffParams,
 ): Promise<Record<string, unknown>> {
   const repo = await resolveAuditRepoHandle(repoId, params.repo);
-  const projection = buildAuditProjection(
-    (await new LocalAuditEventStore(repo.repoPath).load()).events,
-  );
+  const loaded = await loadStateReport(repo.repoPath);
+  if (loaded.ok === false) return loaded.report;
+  const { state } = loaded;
+  const projection = buildAuditProjection(state.events);
   const sessionA = requireProjectedSession(projection.sessions, params.sessionA);
   const sessionB = requireProjectedSession(projection.sessions, params.sessionB);
   const diff = buildAuditSessionDiff(
@@ -232,7 +240,8 @@ export async function gnAuditDiff(
         diff.statusChanged.length > maxEntries ||
         diff.unchanged.length > maxEntries,
     },
-    warnings: [],
+    integrity: state.integrity,
+    warnings: integrityWarnings(state.integrity),
     skipReasons: [],
   };
 }
@@ -243,9 +252,10 @@ export async function gnAuditReplay(
 ): Promise<Record<string, unknown>> {
   const repo = await resolveAuditRepoHandle(repoId, params.repo);
   const sessionId = requiredSession(params);
-  const projection = buildAuditProjection(
-    (await new LocalAuditEventStore(repo.repoPath).load()).events,
-  );
+  const loaded = await loadStateReport(repo.repoPath);
+  if (loaded.ok === false) return loaded.report;
+  const { state } = loaded;
+  const projection = buildAuditProjection(state.events);
   const session = requireProjectedSession(projection.sessions, sessionId);
   const targetHead = params.targetHead ?? (await currentGitHead(repo.repoPath));
   const plan = buildAuditReplayPlan(
@@ -266,7 +276,8 @@ export async function gnAuditReplay(
       total: plan.findings.length,
       truncated: plan.findings.length > maxFindings,
     },
-    warnings: [],
+    integrity: state.integrity,
+    warnings: integrityWarnings(state.integrity),
     skipReasons: [],
   };
 }
@@ -277,9 +288,10 @@ export async function gnAuditExport(
 ): Promise<Record<string, unknown>> {
   const repo = await resolveAuditRepoHandle(repoId, params.repo);
   const sessionId = requiredSession(params);
-  const projection = buildAuditProjection(
-    (await new LocalAuditEventStore(repo.repoPath).load()).events,
-  );
+  const loaded = await loadStateReport(repo.repoPath);
+  if (loaded.ok === false) return loaded.report;
+  const { state } = loaded;
+  const projection = buildAuditProjection(state.events);
   const session = requireProjectedSession(projection.sessions, sessionId);
   const maxFindings = clamp(params.maxFindings, 500);
   const findings = projection.findings
@@ -287,6 +299,7 @@ export async function gnAuditExport(
     .slice(0, maxFindings);
   const json = {
     session,
+    integrity: state.integrity,
     findings,
     bundles: projection.bundles.filter((bundle) => bundle.sessionId === sessionId),
     lintRuns: projection.lintRuns.filter((run) => run.sessionId === sessionId),
@@ -312,7 +325,8 @@ export async function gnAuditExport(
         findings.length <
         projection.findings.filter((finding) => finding.sessionId === sessionId).length,
     },
-    warnings: [],
+    integrity: state.integrity,
+    warnings: integrityWarnings(state.integrity),
     skipReasons: [],
   };
 }
@@ -477,12 +491,44 @@ export async function gnAuditSessionDispatch(
 ): Promise<Record<string, unknown>> {
   const repo = await resolveAuditRepoHandle(repoId, params.repo);
   const sessionId = requiredSession(params);
-  const lockValidation = await validateManagerSession(repo.repoPath, sessionId);
+  let lockValidation: Awaited<ReturnType<typeof validateManagerSession>>;
+  try {
+    lockValidation = await validateManagerSession(repo.repoPath, sessionId);
+  } catch (error) {
+    if (isAuditChainError(error)) {
+      return auditChainFailureReport('audit-session-dispatch', sessionId, error);
+    }
+    throw error;
+  }
   if (lockValidation.ok === false) {
     return managerRefusal('audit-session-dispatch', sessionId, lockValidation);
   }
 
-  const managerState = await loadManagerState(repo.repoPath, sessionId);
+  let managerState: Awaited<ReturnType<typeof loadManagerState>>;
+  try {
+    managerState = await loadManagerState(repo.repoPath, sessionId);
+  } catch (error) {
+    if (isAuditChainError(error)) {
+      return auditChainFailureReport('audit-session-dispatch', sessionId, error);
+    }
+    throw error;
+  }
+  const chainFailure = auditChainFailure(managerState.state.integrity);
+  if (chainFailure !== undefined) {
+    return {
+      version: 1,
+      action: 'audit-session-dispatch',
+      ok: false,
+      code: 'ERR_AUDIT_CHAIN_BROKEN',
+      firstBrokenSequence: chainFailure.firstBrokenSequence,
+      reason: chainFailure.reason,
+      sessionId,
+      integrity: managerState.state.integrity,
+      warnings: [],
+      skipReasons: ['audit-chain-broken'],
+    };
+  }
+  const integrity = managerState.state.integrity;
   const bundle = selectPersistedBundle(managerState.projection.bundles, sessionId, params.bundleId);
   if (bundle === undefined) {
     return managerError(
@@ -509,7 +555,8 @@ export async function gnAuditSessionDispatch(
       bundleId: bundle.id,
       blockedFindings,
       duplicateOnlyChildren,
-      warnings: [],
+      integrity,
+      warnings: integrityWarnings(integrity),
       skipReasons: duplicateOnlyChildren
         ? ['duplicate-only-children']
         : blockedFindings.map((finding) => finding.reason),
@@ -531,7 +578,8 @@ export async function gnAuditSessionDispatch(
     bundleId: bundle.id,
     lockValidation,
     dispatch,
-    warnings: collectWarnings(dispatch),
+    integrity,
+    warnings: [...integrityWarnings(integrity), ...collectWarnings(dispatch)],
     skipReasons: [],
   };
 }
@@ -704,10 +752,84 @@ async function validateManagerSession(
 }
 
 async function loadManagerState(repoPath: string, sessionId: string) {
-  const state = await new LocalAuditEventStore(repoPath).load();
+  let state: Awaited<ReturnType<LocalAuditEventStore['load']>>;
+  try {
+    state = await new LocalAuditEventStore(repoPath).load();
+  } catch (error) {
+    throw auditChainError('audit event store load/parse failed', error);
+  }
   const projection = buildAuditProjection(state.events);
   requireProjectedSession(projection.sessions, sessionId);
   return { state, projection };
+}
+
+async function loadStateReport(
+  repoPath: string,
+): Promise<
+  | { ok: true; state: Awaited<ReturnType<LocalAuditEventStore['load']>> }
+  | { ok: false; report: Record<string, unknown> }
+> {
+  try {
+    return { ok: true, state: await new LocalAuditEventStore(repoPath).load() };
+  } catch (error) {
+    const failure = auditChainError('audit event store load/parse failed', error);
+    return {
+      ok: false,
+      report: {
+        version: 1,
+        ok: false,
+        code: failure.code,
+        reason: failure.reason,
+        integrity: { status: 'BROKEN', reason: failure.reason },
+        warnings: [],
+        skipReasons: ['audit-chain-broken'],
+      },
+    };
+  }
+}
+
+function auditChainFailure(
+  integrity: Awaited<ReturnType<LocalAuditEventStore['load']>>['integrity'],
+): { firstBrokenSequence?: number; reason: string } | undefined {
+  if (integrity === undefined) return { reason: 'missing-integrity-envelope' };
+  if (isDispatchableIntegrity(integrity)) return undefined;
+  return {
+    firstBrokenSequence: integrity.firstBrokenSequence,
+    reason:
+      integrity.reason ??
+      (integrity.status === 'LEGACY_UNVERIFIED'
+        ? 'legacy-unverified-chain'
+        : 'unknown-integrity-failure'),
+  };
+}
+
+function isAuditChainError(
+  error: unknown,
+): error is Error & {
+  code: 'ERR_AUDIT_CHAIN_BROKEN';
+  firstBrokenSequence?: number;
+  reason: string;
+} {
+  return error instanceof Error && 'code' in error && error.code === 'ERR_AUDIT_CHAIN_BROKEN';
+}
+
+function auditChainFailureReport(
+  action: string,
+  sessionId: string,
+  error: Error & { code: 'ERR_AUDIT_CHAIN_BROKEN'; firstBrokenSequence?: number; reason: string },
+): Record<string, unknown> {
+  return {
+    version: 1,
+    action,
+    ok: false,
+    code: error.code,
+    firstBrokenSequence: error.firstBrokenSequence,
+    reason: error.reason,
+    sessionId,
+    integrity: { status: 'BROKEN', reason: error.reason },
+    warnings: [],
+    skipReasons: ['audit-chain-broken'],
+  };
 }
 
 interface RepeatedFindingTombstoneMatch {
@@ -1010,6 +1132,7 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
 
 function renderAuditExportMarkdown(input: {
   session: { id: string; targetRepo: string; targetHead: string };
+  integrity?: { status: string; firstBrokenSequence?: number; reason?: string };
   findings: Array<{ id: string; status: string; title: string }>;
   bundles: Array<{ id: string; findingIds: string[] }>;
 }): string {
@@ -1024,6 +1147,13 @@ function renderAuditExportMarkdown(input: {
     `- Repo: ${input.session.targetRepo}`,
     `- Target HEAD: ${input.session.targetHead}`,
     `- Session: ${input.session.id}`,
+    '',
+    'Integrity:',
+    `- Status: ${input.integrity?.status ?? 'UNKNOWN'}`,
+    ...(input.integrity?.firstBrokenSequence !== undefined
+      ? [`- First broken sequence: ${input.integrity.firstBrokenSequence}`]
+      : []),
+    ...(input.integrity?.reason !== undefined ? [`- Reason: ${input.integrity.reason}`] : []),
     '',
     'Findings:',
     ...Array.from(counts.entries())

--- a/ontoindex/src/mcp/super/audit-session-tools.ts
+++ b/ontoindex/src/mcp/super/audit-session-tools.ts
@@ -803,9 +803,7 @@ function auditChainFailure(
   };
 }
 
-function isAuditChainError(
-  error: unknown,
-): error is Error & {
+function isAuditChainError(error: unknown): error is Error & {
   code: 'ERR_AUDIT_CHAIN_BROKEN';
   firstBrokenSequence?: number;
   reason: string;

--- a/ontoindex/src/mcp/super/diagnose.ts
+++ b/ontoindex/src/mcp/super/diagnose.ts
@@ -567,10 +567,23 @@ export async function gnDiagnose(
         };
 
         if (freshReport.preCheck.isStale) {
+          // autoAnalyze is refused while the worktree is dirty, because the
+          // analyzer reads working-tree files but publishes under a commit
+          // source identity. Recommending it here regardless of worktree state
+          // advertises a repair that its own precondition guarantees will fail.
+          const dirtyFileCount = freshReport.dirtyFileCount;
+          // `null` (git probe failed) and `undefined` (field absent) are both
+          // unproven-clean, and autoAnalyze refuses each of them.
+          const worktreeStateUnknown = dirtyFileCount === null || dirtyFileCount === undefined;
+          const worktreeBlocksAutoAnalyze = worktreeStateUnknown || dirtyFileCount > 0;
           recommendations.push({
             severity: 'WARN',
             detail: `Index is stale (indexed ${freshReport.preCheck.indexedCommit} vs current ${freshReport.preCheck.currentCommit})`,
-            fix: 'gn_ensure_fresh({autoAnalyze: true})',
+            fix: worktreeBlocksAutoAnalyze
+              ? worktreeStateUnknown
+                ? 'Worktree status is unavailable, so gn_ensure_fresh({autoAnalyze: true}) will be refused. Restore git status, then refresh.'
+                : `Commit or stash the ${dirtyFileCount} changed file${dirtyFileCount === 1 ? '' : 's'} first; gn_ensure_fresh({autoAnalyze: true}) is refused while the worktree is dirty.`
+              : 'gn_ensure_fresh({autoAnalyze: true})',
           });
         }
       }

--- a/ontoindex/src/mcp/super/ensure-fresh.ts
+++ b/ontoindex/src/mcp/super/ensure-fresh.ts
@@ -84,6 +84,15 @@ export interface EnsureFreshReport {
   headCommit?: string;
   isStale?: boolean;
   dirtyFileCount?: number | null;
+  /**
+   * Bounded split of `dirtyFileCount`. Tracked edits sit on top of an indexed
+   * commit; untracked source files are absent from the graph entirely. Optional
+   * and additive: consumers that only read `dirtyFileCount` are unaffected.
+   */
+  dirtyWorktreeBreakdown?: {
+    trackedChangedCount: number | null;
+    untrackedCount: number | null;
+  };
   scopeConfidence?: ScopeConfidence;
   runtimeHealth?: RuntimeHealthSnapshot;
   actionsTaken: string[];
@@ -269,7 +278,19 @@ function currentCliCommand(): { command: string; argsPrefix: string[]; displayPr
   return { command: 'ontoindex', argsPrefix: [], displayPrefix: 'ontoindex' };
 }
 
-async function countDirtyFiles(repoRoot: string): Promise<number | null> {
+/**
+ * Bounded worktree breakdown. Tracked edits are already represented in the graph
+ * at their indexed commit, while untracked source files are unknown to it, so
+ * agents need the two counts separately to calibrate rather than blanket-
+ * discount every `dirty` report.
+ */
+interface DirtyWorktreeSummary {
+  dirtyFileCount: number | null;
+  trackedChangedCount: number | null;
+  untrackedCount: number | null;
+}
+
+async function summarizeDirtyWorktree(repoRoot: string): Promise<DirtyWorktreeSummary> {
   try {
     const output = (
       await execFileText('git', ['status', '--porcelain'], {
@@ -278,10 +299,18 @@ async function countDirtyFiles(repoRoot: string): Promise<number | null> {
         maxBuffer: GIT_PROBE_MAX_BUFFER,
       })
     ).trim();
-    if (output.length === 0) return 0;
-    return output.split('\n').filter(Boolean).length;
+    if (output.length === 0) {
+      return { dirtyFileCount: 0, trackedChangedCount: 0, untrackedCount: 0 };
+    }
+    const lines = output.split('\n').filter(Boolean);
+    const untrackedCount = lines.filter((line) => line.startsWith('??')).length;
+    return {
+      dirtyFileCount: lines.length,
+      trackedChangedCount: lines.length - untrackedCount,
+      untrackedCount,
+    };
   } catch {
-    return null;
+    return { dirtyFileCount: null, trackedChangedCount: null, untrackedCount: null };
   }
 }
 
@@ -381,6 +410,50 @@ function resolveEmbeddingsStatus(input: {
 // Main function
 // ---------------------------------------------------------------------------
 
+/**
+ * Short-lived cache for read-only freshness probes.
+ *
+ * Freshness is the single most-called OntoIndex surface, and repeated probes
+ * within one agent turn re-derive an answer that cannot have changed. Only
+ * read-only calls are cached: any `autoAnalyze` request submits work and must
+ * always execute. The TTL is deliberately short to bound how long a verdict can
+ * lag a concurrent edit; set ONTOINDEX_FRESHNESS_CACHE_MS=0 to disable.
+ */
+const DEFAULT_FRESHNESS_CACHE_MS = 3_000;
+
+interface FreshnessCacheEntry {
+  expiresAt: number;
+  report: EnsureFreshReport;
+}
+
+const freshnessCache = new Map<string, FreshnessCacheEntry>();
+
+function freshnessCacheTtlMs(): number {
+  const raw = process.env.ONTOINDEX_FRESHNESS_CACHE_MS;
+  if (raw == null || raw.trim() === '') return DEFAULT_FRESHNESS_CACHE_MS;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) return DEFAULT_FRESHNESS_CACHE_MS;
+  return Math.floor(value);
+}
+
+/** Test seam: drop every cached freshness verdict. */
+export function resetFreshnessCache(): void {
+  freshnessCache.clear();
+}
+
+function freshnessCacheKey(
+  repoId: string,
+  params: EnsureFreshParams,
+  requiredGraphCapabilities: readonly GraphAuthorityCapability[],
+): string {
+  return JSON.stringify([
+    repoId,
+    params.repo ?? null,
+    params.withEmbeddings === true,
+    requiredGraphCapabilities,
+  ]);
+}
+
 export function gnEnsureFresh(
   repoId: string,
   params: EnsureFreshParams & { legacyResponse: false },
@@ -396,10 +469,33 @@ export async function gnEnsureFresh(
   const requiredGraphCapabilities = normalizeRequiredGraphCapabilities(
     params.requiredGraphCapabilities,
   );
-  const report = await buildEnsureFreshReport(repoId, {
-    ...params,
-    requiredGraphCapabilities,
-  });
+  const cacheable = params.autoAnalyze !== true;
+  const ttlMs = freshnessCacheTtlMs();
+  const cacheKey = freshnessCacheKey(repoId, params, requiredGraphCapabilities);
+  let report: EnsureFreshReport | undefined;
+
+  if (cacheable && ttlMs > 0) {
+    const cached = freshnessCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      report = structuredClone(cached.report);
+    } else if (cached) {
+      freshnessCache.delete(cacheKey);
+    }
+  }
+
+  if (report === undefined) {
+    report = await buildEnsureFreshReport(repoId, {
+      ...params,
+      requiredGraphCapabilities,
+    });
+    if (cacheable && ttlMs > 0) {
+      freshnessCache.set(cacheKey, {
+        expiresAt: Date.now() + ttlMs,
+        report: structuredClone(report),
+      });
+    }
+  }
+
   if (params.legacyResponse !== false) return report;
   const targetContext = await resolveTargetContext({
     repo: params.repo ?? repoId,
@@ -552,13 +648,23 @@ async function buildEnsureFreshReport(
     warnings.push('git rev-parse HEAD returned a malformed commit identity.');
   }
   const isStale = currentCommit !== '' && indexedCommit !== '' && currentCommit !== indexedCommit;
-  const dirtyFileCount = await countDirtyFiles(repoRoot);
+  const dirtyWorktree = await summarizeDirtyWorktree(repoRoot);
+  const dirtyFileCount = dirtyWorktree.dirtyFileCount;
+  const dirtyWorktreeBreakdown = {
+    trackedChangedCount: dirtyWorktree.trackedChangedCount,
+    untrackedCount: dirtyWorktree.untrackedCount,
+  };
   const scopeConfidence = deriveScopeConfidence({
     selectorProvided: selectorResolved,
     cwdFallbackUsed: cwdFallbackUsed || selector === undefined,
     dirtyFileCount,
     isStale,
   });
+  if ((dirtyWorktree.untrackedCount ?? 0) > 0) {
+    warnings.push(
+      `${dirtyWorktree.untrackedCount} untracked file${dirtyWorktree.untrackedCount === 1 ? ' is' : 's are'} absent from the graph entirely; ${dirtyWorktree.trackedChangedCount} tracked change${dirtyWorktree.trackedChangedCount === 1 ? ' is' : 's are'} indexed at the indexed commit.`,
+    );
+  }
 
   // ---- 4. Build preCheck --------------------------------------------------
   const preCheck = { indexedCommit, currentCommit, isStale };
@@ -643,9 +749,14 @@ async function buildEnsureFreshReport(
     analysisSubmission = {
       status: 'blocked',
       reasonCode: 'WORKTREE_DIRTY',
-      message: `The worktree contains ${dirtyFileCount} changed file${dirtyFileCount === 1 ? '' : 's'}; analysis cannot be submitted safely.`,
+      message: `The worktree contains ${dirtyFileCount} changed file${dirtyFileCount === 1 ? '' : 's'}; analysis cannot be submitted safely. Managed analysis reads working-tree files but publishes under the commit source identity "commit:${currentCommit}", so indexing a dirty tree would label uncommitted content with a commit it does not match.`,
     };
-    recommendations.push('Commit or remove worktree changes before retrying autoAnalyze.');
+    recommendations.push(
+      `Commit or stash the ${dirtyFileCount} changed file${dirtyFileCount === 1 ? '' : 's'}, then retry gn_ensure_fresh({autoAnalyze: true}).`,
+    );
+    recommendations.push(
+      'To keep working without refreshing, treat the graph as commit-scoped to the indexed commit and verify uncommitted changes directly from source.',
+    );
   } else if (
     params.autoAnalyze &&
     params.withEmbeddings === true &&
@@ -684,6 +795,7 @@ async function buildEnsureFreshReport(
       headCommit: currentCommit,
       isStale,
       dirtyFileCount,
+      dirtyWorktreeBreakdown,
       scopeConfidence,
       runtimeHealth,
       actionsTaken,
@@ -808,6 +920,7 @@ async function buildEnsureFreshReport(
     headCommit: currentCommit,
     isStale,
     dirtyFileCount,
+    dirtyWorktreeBreakdown,
     scopeConfidence,
     runtimeHealth,
     actionsTaken,

--- a/ontoindex/src/mcp/super/ensure-fresh.ts
+++ b/ontoindex/src/mcp/super/ensure-fresh.ts
@@ -19,6 +19,8 @@ import {
 } from '../../core/analysis/analysis-coordinator.js';
 import {
   ANALYSIS_REQUESTED_CAPABILITIES_VERSION,
+  commitSourceIdentity,
+  worktreeSourceIdentity,
   type AnalysisRequestedCapabilities,
 } from '../../core/analysis/analysis-publication-receipt.js';
 import {
@@ -710,6 +712,9 @@ async function buildEnsureFreshReport(
   const embeddingsRepairRequired = embeddingsStatus.required && embeddingsStatus.status !== 'ok';
   const refreshWorkNeeded =
     isStale ||
+    // Uncommitted edits are absent from a commit-scoped graph, so a dirty tree
+    // is refreshable work even when HEAD already matches the indexed commit.
+    (dirtyFileCount !== null && dirtyFileCount > 0) ||
     (!currentHeadAvailable && indexedCommit !== '') ||
     embeddingsRepairRequired ||
     runtimeHealth.analyzeLock.state === 'stale' ||
@@ -745,18 +750,6 @@ async function buildEnsureFreshReport(
       message: 'Worktree status is unavailable; analysis cannot be submitted safely.',
     };
     recommendations.push('Confirm the repository worktree is clean before retrying autoAnalyze.');
-  } else if (params.autoAnalyze && dirtyFileCount > 0) {
-    analysisSubmission = {
-      status: 'blocked',
-      reasonCode: 'WORKTREE_DIRTY',
-      message: `The worktree contains ${dirtyFileCount} changed file${dirtyFileCount === 1 ? '' : 's'}; analysis cannot be submitted safely. Managed analysis reads working-tree files but publishes under the commit source identity "commit:${currentCommit}", so indexing a dirty tree would label uncommitted content with a commit it does not match.`,
-    };
-    recommendations.push(
-      `Commit or stash the ${dirtyFileCount} changed file${dirtyFileCount === 1 ? '' : 's'}, then retry gn_ensure_fresh({autoAnalyze: true}).`,
-    );
-    recommendations.push(
-      'To keep working without refreshing, treat the graph as commit-scoped to the indexed commit and verify uncommitted changes directly from source.',
-    );
   } else if (
     params.autoAnalyze &&
     params.withEmbeddings === true &&
@@ -844,12 +837,25 @@ async function buildEnsureFreshReport(
         includePaths: [],
         pipelineProfile: 'full',
       });
+      const manifestDigest = sourceManifestDigest(manifest);
+      // A dirty tree is analyzed as-is, but it must not be published under a
+      // commit identity whose content it does not match. Identify those runs by
+      // the manifest digest that hashed the exact analyzed bytes.
+      const analyzingDirtyWorktree = dirtyFileCount > 0;
+      const sourceIdentity = analyzingDirtyWorktree
+        ? worktreeSourceIdentity(manifestDigest)
+        : commitSourceIdentity(currentCommit);
+      if (analyzingDirtyWorktree) {
+        warnings.push(
+          `Analyzing ${dirtyFileCount} uncommitted change${dirtyFileCount === 1 ? '' : 's'}; results publish under working-tree identity "${sourceIdentity}" rather than commit ${currentCommit}.`,
+        );
+      }
       const submitted = await submitAnalysisJob({
         repoPath: repoRoot,
         targetHead: currentCommit,
-        sourceIdentity: `commit:${currentCommit}`,
+        sourceIdentity,
         requestedCapabilities,
-        sourceManifestDigest: sourceManifestDigest(manifest),
+        sourceManifestDigest: manifestDigest,
         command: cli.command,
         args,
         options: { withEmbeddings: params.withEmbeddings === true },

--- a/ontoindex/src/mcp/super/ensure-fresh.ts
+++ b/ontoindex/src/mcp/super/ensure-fresh.ts
@@ -18,16 +18,25 @@ import {
   type AnalysisJobRecord,
 } from '../../core/analysis/analysis-coordinator.js';
 import {
+  ANALYSIS_REQUESTED_CAPABILITIES_VERSION,
+  type AnalysisRequestedCapabilities,
+} from '../../core/analysis/analysis-publication-receipt.js';
+import {
+  computeSourceManifest,
+  sourceManifestDigest,
+} from '../../core/indexing/source-manifest.js';
+import {
   readRuntimeHealth,
   type RuntimeHealthSnapshot,
 } from '../../core/runtime/runtime-health.js';
-import { loadMeta, type RepoMeta } from '../../storage/repo-manager.js';
-import type { ScopeConfidence } from '../shared/target-context.js';
+import { readActiveGenerationMeta, type RepoMeta } from '../../storage/repo-manager.js';
+import type { GraphAuthorityCapability, ScopeConfidence } from '../shared/target-context.js';
 import { resolveTargetContext } from '../shared/target-context.js';
 import { createEnvelopeFromLegacy } from '../shared/response-envelope.js';
 
 const GIT_PROBE_TIMEOUT_MS = 5_000;
 const GIT_PROBE_MAX_BUFFER = 1024 * 1024;
+const GIT_HEAD = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -36,6 +45,7 @@ const GIT_PROBE_MAX_BUFFER = 1024 * 1024;
 export interface EnsureFreshParams {
   repo?: string;
   withEmbeddings?: boolean; // default: false
+  requiredGraphCapabilities?: readonly GraphAuthorityCapability[]; // default: ['symbols']
   autoAnalyze?: boolean; // default: false (require explicit confirm)
   killMcpForLock?: boolean; // deprecated; advisory only for safety
   legacyResponse?: boolean; // default: true
@@ -46,7 +56,7 @@ export type EmbeddingDriftStatus = 'ok' | 'missing' | 'metadata-unavailable' | '
 export type AnalysisSubmission =
   | { status: 'not-requested' }
   | { status: 'not-needed' }
-  | { status: 'blocked'; reasonCode: string; message: string }
+  | { status: 'blocked'; reasonCode: string; message: string; jobId?: string }
   | { status: 'queued'; jobId: string }
   | { status: 'reused'; jobId: string }
   | {
@@ -65,6 +75,8 @@ export interface EnsureFreshReport {
     status: EmbeddingDriftStatus;
     reason?: string;
     repairCommand?: string;
+    expectedModelHash?: string;
+    actualModelHash?: string;
   };
   repoLabel?: string;
   repoPath?: string;
@@ -82,6 +94,28 @@ export interface EnsureFreshReport {
   recommendations: string[];
 }
 
+const GRAPH_CAPABILITY_ORDER: readonly GraphAuthorityCapability[] = [
+  'impact',
+  'processes',
+  'symbols',
+];
+
+function normalizeRequiredGraphCapabilities(
+  capabilities: readonly GraphAuthorityCapability[] | undefined,
+): GraphAuthorityCapability[] {
+  const requested = capabilities ?? ['symbols'];
+  const normalized = [...new Set(requested)].sort() as GraphAuthorityCapability[];
+  if (
+    normalized.length === 0 ||
+    requested.some((capability) => !GRAPH_CAPABILITY_ORDER.includes(capability))
+  ) {
+    throw new Error(
+      'requiredGraphCapabilities must be a non-empty array containing only symbols, impact, or processes.',
+    );
+  }
+  return normalized;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -90,6 +124,7 @@ interface RegistryEntry {
   name?: string;
   path?: string;
   lastCommit?: string;
+  indexedAt?: string;
   stats?: {
     embeddings?: number;
   };
@@ -272,25 +307,29 @@ function resolveEmbeddingsStatus(input: {
   const count = input.repoMeta?.stats?.embeddings ?? 0;
   const metadataHash = input.repoMeta?.model_hash?.trim() || undefined;
   const currentHash = input.currentEmbeddingModelHash?.trim() || undefined;
-  const required = input.withEmbeddings === true && count === 0;
+  const requested = input.withEmbeddings === true;
+  const requestedRepairCommand = `ontoindex analyze${input.isStale ? '' : ' --force'} --embeddings`;
 
   if (!input.repoMeta) {
     return {
       count,
-      required,
+      required: requested,
       status: 'metadata-unavailable',
       reason: 'repo meta.json is unavailable',
-      repairCommand: 'ontoindex analyze',
+      repairCommand: requested ? requestedRepairCommand : 'ontoindex analyze',
+      ...(currentHash ? { expectedModelHash: currentHash } : {}),
     };
   }
 
   if (count === 0) {
     return {
       count,
-      required,
+      required: requested,
       status: 'missing',
       reason: 'embeddings are not populated in repo metadata',
-      repairCommand: `ontoindex analyze${input.isStale ? '' : ' --force'} --embeddings`,
+      repairCommand: requestedRepairCommand,
+      ...(currentHash ? { expectedModelHash: currentHash } : {}),
+      ...(metadataHash ? { actualModelHash: metadataHash } : {}),
     };
   }
 
@@ -298,36 +337,43 @@ function resolveEmbeddingsStatus(input: {
     if (metadataHash && !currentHash) {
       return {
         count,
-        required,
+        required: false,
         status: 'ok',
         reason: 'runtime embedding model hash is not set; drift check skipped',
+        actualModelHash: metadataHash,
       };
     }
     return {
       count,
-      required,
+      required: requested,
       status: 'metadata-unavailable',
       reason: !metadataHash
         ? 'embedding fingerprint is missing from repo metadata'
         : 'ONTOINDEX_EMBEDDING_MODEL_HASH is not set',
       repairCommand: 'ontoindex analyze --force --embeddings',
+      ...(currentHash ? { expectedModelHash: currentHash } : {}),
+      ...(metadataHash ? { actualModelHash: metadataHash } : {}),
     };
   }
 
   if (metadataHash !== currentHash) {
     return {
       count,
-      required,
+      required: requested,
       status: 'drifted',
       reason: `embedding model hash mismatch: meta.json has "${metadataHash}" but the current environment has "${currentHash}"`,
       repairCommand: 'ontoindex analyze --force --embeddings',
+      expectedModelHash: currentHash,
+      actualModelHash: metadataHash,
     };
   }
 
   return {
     count,
-    required,
+    required: false,
     status: 'ok',
+    expectedModelHash: currentHash,
+    actualModelHash: metadataHash,
   };
 }
 
@@ -347,12 +393,18 @@ export async function gnEnsureFresh(
   repoId: string,
   params: EnsureFreshParams,
 ): Promise<EnsureFreshReport | ReturnType<typeof createEnvelopeFromLegacy<EnsureFreshReport>>> {
-  const report = await buildEnsureFreshReport(repoId, params);
+  const requiredGraphCapabilities = normalizeRequiredGraphCapabilities(
+    params.requiredGraphCapabilities,
+  );
+  const report = await buildEnsureFreshReport(repoId, {
+    ...params,
+    requiredGraphCapabilities,
+  });
   if (params.legacyResponse !== false) return report;
   const targetContext = await resolveTargetContext({
     repo: params.repo ?? repoId,
     verifyGraphAuthority: true,
-    requiredGraphCapabilities: ['symbols'],
+    requiredGraphCapabilities,
   });
   return createEnvelopeFromLegacy({
     legacy: report,
@@ -388,6 +440,9 @@ async function buildEnsureFreshReport(
   repoId: string,
   params: EnsureFreshParams,
 ): Promise<EnsureFreshReport> {
+  const requiredGraphCapabilities = normalizeRequiredGraphCapabilities(
+    params.requiredGraphCapabilities,
+  );
   const warnings: string[] = [];
   const recommendations: string[] = [];
   const actionsTaken: string[] = [];
@@ -454,7 +509,9 @@ async function buildEnsureFreshReport(
   }
 
   // ---- 3. Get current HEAD commit from the indexed repo path --------------
-  const repoMeta = await loadMeta(join(repoRoot, '.ontoindex'));
+  const repoStoragePath = join(repoRoot, '.ontoindex');
+  const generationMeta = await readActiveGenerationMeta(repoStoragePath);
+  const repoMeta = generationMeta.meta;
   let currentCommit = '';
   try {
     currentCommit = (
@@ -468,7 +525,32 @@ async function buildEnsureFreshReport(
     warnings.push('git rev-parse HEAD failed: ' + String(err));
   }
 
-  const indexedCommit: string = entry.lastCommit ?? '';
+  const registryIndexedCommit: string = entry.lastCommit ?? '';
+  const trustedMetadataIndexedCommit =
+    generationMeta.authority !== 'untrusted' ? (repoMeta?.lastCommit ?? '') : '';
+  const indexedCommit = trustedMetadataIndexedCommit || registryIndexedCommit;
+  if (generationMeta.authority === 'untrusted') {
+    warnings.push(
+      `Active generation metadata authority is untrusted (${generationMeta.reason ?? 'unknown reason'}); ${
+        registryIndexedCommit
+          ? `using registry commit ${registryIndexedCommit} as a conservative indexed-commit fallback`
+          : 'no trusted indexed-commit fallback is available'
+      }. Generation metadata is excluded from commit, embeddings, and runtime claims.`,
+    );
+  }
+  if (
+    trustedMetadataIndexedCommit &&
+    registryIndexedCommit &&
+    trustedMetadataIndexedCommit !== registryIndexedCommit
+  ) {
+    warnings.push(
+      `The registry indexed commit ${registryIndexedCommit} lags trusted index metadata ${trustedMetadataIndexedCommit}; using trusted metadata as local freshness authority.`,
+    );
+  }
+  const currentHeadAvailable = GIT_HEAD.test(currentCommit);
+  if (currentCommit && !currentHeadAvailable) {
+    warnings.push('git rev-parse HEAD returned a malformed commit identity.');
+  }
   const isStale = currentCommit !== '' && indexedCommit !== '' && currentCommit !== indexedCommit;
   const dirtyFileCount = await countDirtyFiles(repoRoot);
   const scopeConfidence = deriveScopeConfidence({
@@ -480,10 +562,37 @@ async function buildEnsureFreshReport(
 
   // ---- 4. Build preCheck --------------------------------------------------
   const preCheck = { indexedCommit, currentCommit, isStale };
-  const runtimeHealth = await readRuntimeHealth(repoRoot, {
+  const runtimeFallbackMeta: RepoMeta | null =
+    repoMeta ??
+    (registryIndexedCommit
+      ? {
+          repoPath: repoRoot,
+          lastCommit: registryIndexedCommit,
+          indexedAt: entry.indexedAt ?? '',
+        }
+      : null);
+  let runtimeHealth = await readRuntimeHealth(repoRoot, {
     repoLabel: entry.name ?? selector ?? repoRoot,
-    meta: repoMeta,
+    meta: runtimeFallbackMeta,
   });
+  if (
+    generationMeta.authority === 'untrusted' &&
+    runtimeHealth.freshnessState !== 'failed-after-partial-run'
+  ) {
+    runtimeHealth = {
+      ...runtimeHealth,
+      indexedCommit: registryIndexedCommit || null,
+      freshnessState: 'untrusted',
+      degradedReason: 'active generation metadata authority is untrusted',
+      repairCommand: 'ontoindex analyze --force',
+      repairAction: {
+        tool: 'ontoindex',
+        command: 'analyze',
+        args: ['--force'],
+        reason: 'rebuild untrusted generation metadata through managed analysis',
+      },
+    };
+  }
 
   // ---- 5. Embeddings status -----------------------------------------------
   const embeddingsStatus = resolveEmbeddingsStatus({
@@ -492,6 +601,13 @@ async function buildEnsureFreshReport(
     isStale,
     withEmbeddings: params.withEmbeddings,
   });
+  const embeddingsRepairRequired = embeddingsStatus.required && embeddingsStatus.status !== 'ok';
+  const refreshWorkNeeded =
+    isStale ||
+    (!currentHeadAvailable && indexedCommit !== '') ||
+    embeddingsRepairRequired ||
+    runtimeHealth.analyzeLock.state === 'stale' ||
+    runtimeHealth.freshnessState === 'failed-after-partial-run';
 
   // ---- 6. Recommendations (always populated) ------------------------------
   if (isStale) {
@@ -509,7 +625,39 @@ async function buildEnsureFreshReport(
     );
   }
 
-  if (
+  if (params.autoAnalyze && !currentHeadAvailable) {
+    analysisSubmission = {
+      status: 'blocked',
+      reasonCode: 'HEAD_UNAVAILABLE',
+      message: 'A valid 40- or 64-character git HEAD is unavailable; analysis cannot be submitted.',
+    };
+    recommendations.push('Restore a valid git HEAD before retrying autoAnalyze.');
+  } else if (params.autoAnalyze && dirtyFileCount === null) {
+    analysisSubmission = {
+      status: 'blocked',
+      reasonCode: 'WORKTREE_STATUS_UNAVAILABLE',
+      message: 'Worktree status is unavailable; analysis cannot be submitted safely.',
+    };
+    recommendations.push('Confirm the repository worktree is clean before retrying autoAnalyze.');
+  } else if (params.autoAnalyze && dirtyFileCount > 0) {
+    analysisSubmission = {
+      status: 'blocked',
+      reasonCode: 'WORKTREE_DIRTY',
+      message: `The worktree contains ${dirtyFileCount} changed file${dirtyFileCount === 1 ? '' : 's'}; analysis cannot be submitted safely.`,
+    };
+    recommendations.push('Commit or remove worktree changes before retrying autoAnalyze.');
+  } else if (
+    params.autoAnalyze &&
+    params.withEmbeddings === true &&
+    !process.env.ONTOINDEX_EMBEDDING_MODEL_HASH?.trim()
+  ) {
+    analysisSubmission = {
+      status: 'blocked',
+      reasonCode: 'EMBEDDING_MODEL_IDENTITY_UNAVAILABLE',
+      message:
+        'ONTOINDEX_EMBEDDING_MODEL_HASH must be set to a non-empty model identity before requesting managed embedding analysis.',
+    };
+  } else if (
     params.autoAnalyze &&
     runtimeHealth.freshnessState === 'untrusted' &&
     runtimeHealth.analyzeLock.state !== 'stale'
@@ -545,15 +693,10 @@ async function buildEnsureFreshReport(
     };
   }
 
-  // ---- 7. Auto-analyze (only when explicitly requested AND stale) ---------
+  // ---- 7. Auto-analyze (only when explicitly requested and work is needed) -
   let analysisJob: AnalysisJobRecord | undefined;
 
-  if (
-    params.autoAnalyze &&
-    (isStale ||
-      runtimeHealth.analyzeLock.state === 'stale' ||
-      runtimeHealth.freshnessState === 'failed-after-partial-run')
-  ) {
+  if (params.autoAnalyze && refreshWorkNeeded && analysisSubmission.status === 'not-needed') {
     // Note: this CAN block on DuckDB write-lock if MCP processes are running.
     if (params.killMcpForLock) {
       warnings.push(
@@ -569,13 +712,32 @@ async function buildEnsureFreshReport(
     const forceRecovery =
       runtimeHealth.analyzeLock.state === 'stale' ||
       runtimeHealth.freshnessState === 'failed-after-partial-run';
-    if (forceRecovery) args.push('--force');
+    const forceEmbeddingsRepair = !isStale && embeddingsRepairRequired;
+    const forceAnalyze = forceRecovery || forceEmbeddingsRepair;
+    if (forceAnalyze) args.push('--force');
     if (params.withEmbeddings) args.push('--embeddings');
 
     try {
+      const requestedCapabilities: AnalysisRequestedCapabilities = {
+        version: ANALYSIS_REQUESTED_CAPABILITIES_VERSION,
+        graph: true,
+        graphCapabilities: requiredGraphCapabilities,
+        embeddings: params.withEmbeddings === true,
+        embeddingModelHash:
+          params.withEmbeddings === true
+            ? process.env.ONTOINDEX_EMBEDDING_MODEL_HASH!.trim()
+            : null,
+      };
+      const manifest = await computeSourceManifest(repoRoot, {
+        includePaths: [],
+        pipelineProfile: 'full',
+      });
       const submitted = await submitAnalysisJob({
         repoPath: repoRoot,
         targetHead: currentCommit,
+        sourceIdentity: `commit:${currentCommit}`,
+        requestedCapabilities,
+        sourceManifestDigest: sourceManifestDigest(manifest),
         command: cli.command,
         args,
         options: { withEmbeddings: params.withEmbeddings === true },
@@ -586,7 +748,7 @@ async function buildEnsureFreshReport(
         jobId: analysisJob.id,
       };
       actionsTaken.push(
-        `${submitted.reused ? 'Reused' : 'Started'} analysis job ${analysisJob.id}: ${cli.displayPrefix} analyze${forceRecovery ? ' --force' : ''}${params.withEmbeddings ? ' --embeddings' : ''}`,
+        `${submitted.reused ? 'Reused' : 'Started'} analysis job ${analysisJob.id}: ${cli.displayPrefix} analyze${forceAnalyze ? ' --force' : ''}${params.withEmbeddings ? ' --embeddings' : ''}`,
       );
       recommendations.push(
         `Poll gn_analyze_job with jobId "${analysisJob.id}" for terminal status, exit code, generation ID, and log path.`,
@@ -597,16 +759,34 @@ async function buildEnsureFreshReport(
         err && typeof err === 'object' && 'code' in err && typeof err.code === 'string'
           ? err.code
           : undefined;
-      analysisSubmission = {
-        status: 'failed',
-        errorCode: 'ANALYZE_JOB_SUBMISSION_FAILED',
-        ...(causeCode ? { causeCode } : {}),
-        message,
-      };
-      warnings.push('analyze job submission failed: ' + message);
-      recommendations.push(
-        'Inspect any active analysis job under .ontoindex/analysis-jobs before retrying autoAnalyze.',
-      );
+      if (causeCode === 'LOCK_CONFLICT' || causeCode === 'ACTIVE_JOB_CONFLICT') {
+        const activeJobId =
+          causeCode === 'ACTIVE_JOB_CONFLICT' &&
+          err &&
+          typeof err === 'object' &&
+          'activeJobId' in err &&
+          typeof err.activeJobId === 'string'
+            ? err.activeJobId
+            : undefined;
+        analysisSubmission = {
+          status: 'blocked',
+          reasonCode: causeCode,
+          message,
+          ...(activeJobId ? { jobId: activeJobId } : {}),
+        };
+        warnings.push('analyze job submission blocked: ' + message);
+      } else {
+        analysisSubmission = {
+          status: 'failed',
+          errorCode: 'ANALYZE_JOB_SUBMISSION_FAILED',
+          ...(causeCode ? { causeCode } : {}),
+          message,
+        };
+        warnings.push('analyze job submission failed: ' + message);
+        recommendations.push(
+          'Inspect any active analysis job under .ontoindex/analysis-jobs before retrying autoAnalyze.',
+        );
+      }
     }
   }
 

--- a/ontoindex/src/mcp/super/safe-edit-check.ts
+++ b/ontoindex/src/mcp/super/safe-edit-check.ts
@@ -742,8 +742,13 @@ export async function gnSafeEditCheck(
     const report: EditCheckReport = {
       version: 1,
       symbol: { nodeId: '', name: params.symbol, filePath: '', kind: '' },
-      verdict: 'SAFE',
-      reasoning: 'Symbol not found in index — no graph risk assessed.',
+      // An unresolved symbol means no graph evidence was available, which is an
+      // absence of proof rather than proof of safety. Report CAUTION so a failed
+      // precheck cannot yield the most permissive verdict, matching gn_can_delete
+      // and impact's UNKNOWN handling for the same condition.
+      verdict: 'CAUTION',
+      reasoning:
+        'Symbol not found in index — no graph risk assessed. Absence of graph evidence is not evidence of edit safety; the index may be stale or the symbol may be new.',
       blastRadius: {
         upstreamCount: 0,
         upstreamFiles: [],
@@ -757,7 +762,8 @@ export async function gnSafeEditCheck(
         {
           check: 'symbol_in_index',
           passed: false,
-          detail: 'Symbol not found in graph index.',
+          detail:
+            'Symbol not found in graph index. Verify the symbol name and index freshness before editing.',
         },
       ],
       warnings,

--- a/ontoindex/src/mcp/super/tool-definitions.ts
+++ b/ontoindex/src/mcp/super/tool-definitions.ts
@@ -26,7 +26,7 @@ interface ToolDefinition {
         type: string | string[];
         description?: string;
         enum?: string[];
-        items?: { type: string };
+        items?: { type: string; enum?: string[] };
         default?: unknown;
         minimum?: number;
         maximum?: number;
@@ -381,6 +381,13 @@ export const ONTOINDEX_SUPER_TOOLS: ToolDefinition[] = [
           description: 'Also check and populate embeddings. Default: false.',
           default: false,
         },
+        requiredGraphCapabilities: {
+          type: 'array',
+          items: { type: 'string', enum: ['symbols', 'impact', 'processes'] },
+          description:
+            'Required graph capabilities for freshness and managed analysis. Values are deduplicated and normalized; default: ["symbols"].',
+          default: ['symbols'],
+        },
         autoAnalyze: {
           type: 'boolean',
           description:
@@ -401,7 +408,7 @@ export const ONTOINDEX_SUPER_TOOLS: ToolDefinition[] = [
   {
     name: 'gn_analyze_job',
     description:
-      'Observe or cancel a durable repository analysis job previously returned by gn_ensure_fresh(autoAnalyze=true).',
+      'Observe or cancel a durable repository analysis job previously returned by gn_ensure_fresh(autoAnalyze=true). Successful recovery requires exact commit source identity, a matching publication receipt, and a clean committed-HEAD post-check.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/ontoindex/src/storage/repo-manager.ts
+++ b/ontoindex/src/storage/repo-manager.ts
@@ -117,9 +117,30 @@ export interface IndexGenerationPaths {
   snapshotPath: string;
 }
 
+export type ActiveGenerationMetaAuthority = 'active-generation' | 'legacy-root' | 'untrusted';
+
+export interface ActiveGenerationMetaPair {
+  activeGeneration: IndexGenerationPaths | null;
+  meta: RepoMeta | null;
+  authority: ActiveGenerationMetaAuthority;
+  reason?:
+    | 'active-generation-metadata-unavailable'
+    | 'active-generation-metadata-mismatch'
+    | 'active-generation-changed-during-read'
+    | 'generation-tagged-root-metadata-without-active-generation'
+    | 'legacy-root-metadata-unavailable';
+}
+
+export interface ActiveGenerationMetaReadDeps {
+  resolveActiveGeneration?: typeof resolveActiveIndexGeneration;
+  readMetaFile?: (metaPath: string) => Promise<RepoMeta | null>;
+}
+
 const ONTOINDEX_DIR = '.ontoindex';
 const GENERATIONS_DIR = 'generations';
 const CURRENT_GENERATION_LINK = 'current';
+const GENERATION_POINTER_LOCK = 'current.mutation.lock';
+const GENERATION_POINTER_LOCK_TIMEOUT_MS = 10_000;
 const REGISTRY_LOCK_TIMEOUT_MS = 10_000;
 const REGISTRY_LOCK_STALE_MS = 2 * 60_000;
 const REGISTRY_LOCK_RETRY_MS = 50;
@@ -225,6 +246,15 @@ export const discardIndexGeneration = async (generation: IndexGenerationPaths): 
   await fs.rm(generation.generationPath, { recursive: true, force: true });
 };
 
+export interface IndexGenerationActivation {
+  activeGeneration: IndexGenerationPaths;
+  previousGeneration: IndexGenerationPaths | null;
+}
+
+export interface IndexGenerationPublication<T> extends IndexGenerationActivation {
+  result: T;
+}
+
 async function replaceWithSymlink(target: string, linkPath: string): Promise<void> {
   const tmpPath = `${linkPath}.${process.pid}.${Date.now()}.tmp`;
   await fs.symlink(target, tmpPath);
@@ -302,12 +332,66 @@ async function migrateLegacyGeneration(storagePath: string): Promise<void> {
   }
 }
 
-export const activateIndexGeneration = async (
+async function withGenerationPointerLock<T>(
+  storagePath: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  await fs.mkdir(storagePath, { recursive: true });
+  const lockPath = path.join(storagePath, GENERATION_POINTER_LOCK);
+  const release = await acquireExclusiveFile(lockPath, GENERATION_POINTER_LOCK_TIMEOUT_MS);
+  if (!release) throw new Error(`Timed out acquiring index generation pointer lock: ${lockPath}`);
+  let result: T | undefined;
+  let callbackError: unknown;
+  try {
+    result = await callback();
+  } catch (err) {
+    callbackError = err;
+  }
+
+  let releaseError: unknown;
+  try {
+    await release();
+  } catch (err) {
+    releaseError = err;
+  }
+
+  if (callbackError !== undefined && releaseError !== undefined) {
+    throw new AggregateError(
+      [callbackError, releaseError],
+      'Index generation pointer mutation failed and its lock could not be released.',
+    );
+  }
+  if (callbackError !== undefined) throw callbackError;
+  if (releaseError !== undefined) throw releaseError;
+  return result as T;
+}
+
+function requirePublishedGeneration(
   storagePath: string,
   generation: IndexGenerationPaths,
-): Promise<IndexGenerationPaths> => {
+): IndexGenerationPaths {
+  const generationId = safeGenerationId(generation.generationId);
+  if (generationId !== generation.generationId) {
+    throw new Error('Index generation id is not canonical');
+  }
+  const generationPath = path.join(storagePath, GENERATIONS_DIR, generationId);
+  if (path.resolve(generation.generationPath) !== path.resolve(generationPath)) {
+    throw new Error('Index generation path is outside the repository generations directory');
+  }
+  return generationPaths(storagePath, generationId, generationPath);
+}
+
+async function activateIndexGenerationLocked(
+  storagePath: string,
+  generation: IndexGenerationPaths,
+): Promise<IndexGenerationActivation> {
+  const generationId = safeGenerationId(generation.generationId);
+  if (generationId !== generation.generationId) {
+    throw new Error('Index generation id is not canonical');
+  }
+  const previousGeneration = await resolveActiveIndexGeneration(storagePath);
   const generationsPath = path.join(storagePath, GENERATIONS_DIR);
-  const finalPath = path.join(generationsPath, generation.generationId);
+  const finalPath = path.join(generationsPath, generationId);
   await fs.rename(generation.generationPath, finalPath);
 
   const currentPath = path.join(storagePath, CURRENT_GENERATION_LINK);
@@ -316,9 +400,113 @@ export const activateIndexGeneration = async (
     .then(() => true)
     .catch(() => false);
   if (!hadCurrentGeneration) await ensureGenerationAliases(storagePath);
-  await replaceWithSymlink(path.join(GENERATIONS_DIR, generation.generationId), currentPath);
-  return generationPaths(storagePath, generation.generationId, finalPath);
-};
+  await replaceWithSymlink(path.join(GENERATIONS_DIR, generationId), currentPath);
+  return {
+    activeGeneration: generationPaths(storagePath, generationId, finalPath),
+    previousGeneration,
+  };
+}
+
+export const activateIndexGenerationTransaction = async (
+  storagePath: string,
+  generation: IndexGenerationPaths,
+): Promise<IndexGenerationActivation> =>
+  withGenerationPointerLock(storagePath, () =>
+    activateIndexGenerationLocked(storagePath, generation),
+  );
+
+export const activateIndexGeneration = async (
+  storagePath: string,
+  generation: IndexGenerationPaths,
+): Promise<IndexGenerationPaths> =>
+  (await activateIndexGenerationTransaction(storagePath, generation)).activeGeneration;
+
+async function removeGenerationAliases(storagePath: string): Promise<void> {
+  for (const filename of ['lbug', 'lbug.wal', 'lbug.lock', 'meta.json', 'snapshot.json']) {
+    const linkPath = path.join(storagePath, filename);
+    try {
+      if ((await fs.readlink(linkPath)) === path.join(CURRENT_GENERATION_LINK, filename)) {
+        await fs.unlink(linkPath);
+      }
+    } catch {}
+  }
+}
+
+async function rollbackIndexGenerationActivationLocked(
+  storagePath: string,
+  expectedActiveGenerationId: string,
+  previousGeneration: IndexGenerationPaths | null,
+): Promise<void> {
+  const expectedId = safeGenerationId(expectedActiveGenerationId);
+  if (expectedId !== expectedActiveGenerationId) {
+    throw new Error('Expected active index generation id is not canonical');
+  }
+  const currentGeneration = await resolveActiveIndexGeneration(storagePath);
+  if (currentGeneration?.generationId !== expectedId) {
+    throw new Error(
+      `Refusing index generation rollback: expected ${expectedId} to remain active, found ${currentGeneration?.generationId ?? 'none'}`,
+    );
+  }
+
+  const currentPath = path.join(storagePath, CURRENT_GENERATION_LINK);
+  if (previousGeneration) {
+    const previous = requirePublishedGeneration(storagePath, previousGeneration);
+    const stat = await fs.lstat(previous.generationPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error('Previous index generation must not be a symbolic link');
+    }
+    if (!stat.isDirectory()) throw new Error('Previous index generation is not a directory');
+    const generationsPath = await fs.realpath(path.join(storagePath, GENERATIONS_DIR));
+    const previousPath = await fs.realpath(previous.generationPath);
+    if (previousPath !== path.join(generationsPath, previous.generationId)) {
+      throw new Error('Previous index generation resolves outside the generations directory');
+    }
+    await replaceWithSymlink(path.join(GENERATIONS_DIR, previous.generationId), currentPath);
+    return;
+  }
+
+  await fs.unlink(currentPath);
+  await removeGenerationAliases(storagePath);
+}
+
+export const rollbackIndexGenerationActivation = async (
+  storagePath: string,
+  expectedActiveGenerationId: string,
+  previousGeneration: IndexGenerationPaths | null,
+): Promise<void> =>
+  withGenerationPointerLock(storagePath, () =>
+    rollbackIndexGenerationActivationLocked(
+      storagePath,
+      expectedActiveGenerationId,
+      previousGeneration,
+    ),
+  );
+
+export const publishIndexGenerationTransaction = async <T>(
+  storagePath: string,
+  generation: IndexGenerationPaths,
+  commit: (activation: IndexGenerationActivation) => Promise<T>,
+): Promise<IndexGenerationPublication<T>> =>
+  withGenerationPointerLock(storagePath, async () => {
+    const activation = await activateIndexGenerationLocked(storagePath, generation);
+    try {
+      return { ...activation, result: await commit(activation) };
+    } catch (commitError) {
+      try {
+        await rollbackIndexGenerationActivationLocked(
+          storagePath,
+          activation.activeGeneration.generationId,
+          activation.previousGeneration,
+        );
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [commitError, rollbackError],
+          'Index generation publication commit failed and the active generation could not be rolled back.',
+        );
+      }
+      throw commitError;
+    }
+  });
 
 export const resolveActiveIndexGeneration = async (
   storagePath: string,
@@ -330,6 +518,102 @@ export const resolveActiveIndexGeneration = async (
   } catch {
     return null;
   }
+};
+
+async function readMetaFile(metaPath: string): Promise<RepoMeta | null> {
+  try {
+    return JSON.parse(await fs.readFile(metaPath, 'utf-8')) as RepoMeta;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the active generation pointer and its metadata as one bounded stable
+ * authority pair. A concurrent activation is retried once; metadata is only
+ * returned when it identifies the exact generation that remains active after
+ * the read. Without an active generation, only generationless legacy root
+ * metadata is trusted.
+ */
+export const readActiveGenerationMeta = async (
+  storagePath: string,
+  deps: ActiveGenerationMetaReadDeps = {},
+): Promise<ActiveGenerationMetaPair> => {
+  const resolveActive = deps.resolveActiveGeneration ?? resolveActiveIndexGeneration;
+  const readMeta = deps.readMetaFile ?? readMetaFile;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const generationBeforeRead = await resolveActive(storagePath);
+    if (!generationBeforeRead) {
+      const legacyMeta = await readMeta(path.join(storagePath, 'meta.json'));
+      const generationAfterRead = await resolveActive(storagePath);
+      if (generationAfterRead) {
+        if (attempt === 0) continue;
+        return {
+          activeGeneration: generationAfterRead,
+          meta: null,
+          authority: 'untrusted',
+          reason: 'active-generation-changed-during-read',
+        };
+      }
+      if (legacyMeta && legacyMeta.generationId === undefined) {
+        return {
+          activeGeneration: null,
+          meta: legacyMeta,
+          authority: 'legacy-root',
+        };
+      }
+      return {
+        activeGeneration: null,
+        meta: null,
+        authority: 'untrusted',
+        reason: legacyMeta
+          ? 'generation-tagged-root-metadata-without-active-generation'
+          : 'legacy-root-metadata-unavailable',
+      };
+    }
+
+    const meta = await readMeta(generationBeforeRead.metaPath);
+    const generationAfterRead = await resolveActive(storagePath);
+    const pointerStable = generationAfterRead?.generationId === generationBeforeRead.generationId;
+    if (!pointerStable) {
+      if (attempt === 0) continue;
+      return {
+        activeGeneration: generationAfterRead,
+        meta: null,
+        authority: 'untrusted',
+        reason: 'active-generation-changed-during-read',
+      };
+    }
+    if (!meta) {
+      return {
+        activeGeneration: generationAfterRead,
+        meta: null,
+        authority: 'untrusted',
+        reason: 'active-generation-metadata-unavailable',
+      };
+    }
+    if (meta.generationId !== generationAfterRead.generationId) {
+      return {
+        activeGeneration: generationAfterRead,
+        meta: null,
+        authority: 'untrusted',
+        reason: 'active-generation-metadata-mismatch',
+      };
+    }
+    return {
+      activeGeneration: generationAfterRead,
+      meta,
+      authority: 'active-generation',
+    };
+  }
+
+  return {
+    activeGeneration: null,
+    meta: null,
+    authority: 'untrusted',
+    reason: 'active-generation-changed-during-read',
+  };
 };
 
 /**
@@ -584,8 +868,11 @@ async function acquireExclusiveFile(
       let released = false;
       return async () => {
         if (released) return;
+        const removed = await removeRegistryLockIfOwner(lockPath, process.pid, token);
+        if (!removed) {
+          throw new Error(`Failed to release owned lock: ${lockPath}`);
+        }
         released = true;
-        await removeRegistryLockIfOwner(lockPath, process.pid, token);
       };
     } catch (err: unknown) {
       if (errorCode(err) !== 'EEXIST') throw err;

--- a/ontoindex/test/integration/audit-cli.test.ts
+++ b/ontoindex/test/integration/audit-cli.test.ts
@@ -1,10 +1,22 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { auditIngestCommand, auditLintCommand, auditVerifyCommand } from '../../src/cli/audit.js';
+import {
+  auditIngestCommand,
+  auditIntegrityCommand,
+  auditLintCommand,
+  auditVerifyCommand,
+} from '../../src/cli/audit.js';
 import { formatAuditVerifySarif } from '../../src/cli/ci-export.js';
 import { LocalAuditEventStore } from '../../src/core/audit-lifecycle/index.js';
 import { expectSchemaMatch, loadJsonFixture } from '../helpers/json-schema.js';
@@ -132,6 +144,234 @@ describe('audit lifecycle CLI', () => {
     );
     expect(xml).toContain('src/app.ts (run) [claim]');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('reports an absent audit store as valid without creating files', async () => {
+    const repo = initRepo();
+
+    await auditIntegrityCommand({ repo, json: true });
+
+    expect(JSON.parse(String(mockLog.mock.calls.at(-1)?.[0]))).toEqual({
+      status: 'VALID',
+      exists: false,
+    });
+    expect(existsSync(path.join(repo, '.ontoindex'))).toBe(false);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('requires both reset acknowledgements and never mutates on a partial reset request', async () => {
+    const repo = initRepo();
+    const store = new LocalAuditEventStore(repo);
+    await store.createSession({
+      id: 'session-reset-guard',
+      targetRepo: 'fixture',
+      targetHead: '0'.repeat(40),
+      sourceHash: 'sha256:report',
+      graphIndexId: 'idx:test',
+      verifierVersion: '0.1.0',
+      sidecarStateHash: 'sidecar:ok',
+      sourcePath: 'audit.md',
+    });
+    const before = readFileSync(store.eventStorePath);
+
+    await auditIntegrityCommand({ repo, json: true, resetBroken: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(readFileSync(store.eventStorePath)).toEqual(before);
+    expect(readdirSync(path.join(repo, '.ontoindex', 'audit'))).not.toContain('recovery');
+  });
+
+  it('reports VALID for an existing healthy schema-v2 store', async () => {
+    const repo = initRepo();
+    const store = new LocalAuditEventStore(repo);
+    await store.createSession({
+      id: 'session-valid',
+      targetRepo: 'fixture',
+      targetHead: '0'.repeat(40),
+      sourceHash: 'sha256:report',
+      graphIndexId: 'idx:test',
+      verifierVersion: '0.1.0',
+      sidecarStateHash: 'sidecar:ok',
+      sourcePath: 'audit.md',
+    });
+
+    await auditIntegrityCommand({ repo, json: true });
+
+    expect(JSON.parse(String(mockLog.mock.calls.at(-1)?.[0]))).toMatchObject({
+      status: 'VALID',
+      exists: true,
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('reports LEGACY_UNVERIFIED for a schema-v1 store through the CLI', async () => {
+    const repo = initRepo();
+    const store = new LocalAuditEventStore(repo);
+    mkdirSync(path.dirname(store.eventStorePath), { recursive: true });
+    writeFileSync(
+      store.eventStorePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        events: [
+          {
+            id: 'legacy-1',
+            type: 'AuditIngested',
+            occurredAt: '2026-05-17T00:00:00.000Z',
+            sessionId: 'session-legacy',
+            session: {
+              id: 'session-legacy',
+              targetRepo: 'fixture',
+              targetHead: '0'.repeat(40),
+              sourceHash: 'sha256:report',
+              graphIndexId: 'idx:test',
+              verifierVersion: '0.1.0',
+              sidecarStateHash: 'sidecar:ok',
+              createdAt: '2026-05-17T00:00:00.000Z',
+              metadata: {},
+            },
+          },
+        ],
+      }),
+    );
+
+    await auditIntegrityCommand({ repo, json: true });
+
+    expect(JSON.parse(String(mockLog.mock.calls.at(-1)?.[0]))).toMatchObject({
+      status: 'LEGACY_UNVERIFIED',
+      exists: true,
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('archives an unverified legacy store through an acknowledged reset', async () => {
+    const repo = initRepo();
+    const store = new LocalAuditEventStore(repo);
+    mkdirSync(path.dirname(store.eventStorePath), { recursive: true });
+    writeFileSync(
+      store.eventStorePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        events: [
+          {
+            id: 'legacy-1',
+            type: 'AuditIngested',
+            occurredAt: '2026-05-17T00:00:00.000Z',
+            sessionId: 'session-legacy',
+            session: {
+              id: 'session-legacy',
+              targetRepo: 'fixture',
+              targetHead: '0'.repeat(40),
+              sourceHash: 'sha256:report',
+              graphIndexId: 'idx:test',
+              verifierVersion: '0.1.0',
+              sidecarStateHash: 'sidecar:ok',
+              createdAt: '2026-05-17T00:00:00.000Z',
+              metadata: {},
+            },
+          },
+        ],
+      }),
+    );
+    const original = readFileSync(store.eventStorePath);
+
+    await auditIntegrityCommand({
+      repo,
+      json: true,
+      resetBroken: true,
+      acknowledgeDataLoss: true,
+    });
+
+    const report = JSON.parse(String(mockLog.mock.calls.at(-1)?.[0]));
+    expect(report).toMatchObject({ status: 'LEGACY_UNVERIFIED', exists: true });
+    expect(readFileSync(String(report.archivePath))).toEqual(original);
+    expect((await store.load()).events).toEqual([]);
+  });
+
+  it('reports broken stores and resets them only after archiving exact bytes', async () => {
+    const repo = initRepo();
+    const store = new LocalAuditEventStore(repo);
+    await store.createSession({
+      id: 'session-broken',
+      targetRepo: 'fixture',
+      targetHead: '0'.repeat(40),
+      sourceHash: 'sha256:report',
+      graphIndexId: 'idx:test',
+      verifierVersion: '0.1.0',
+      sidecarStateHash: 'sidecar:ok',
+      sourcePath: 'audit.md',
+    });
+    const broken = JSON.parse(readFileSync(store.eventStorePath, 'utf8')) as {
+      events: Array<{ checksum: string }>;
+    };
+    broken.events[0].checksum = 'broken';
+    writeFileSync(store.eventStorePath, JSON.stringify(broken));
+    const originalBytes = readFileSync(store.eventStorePath);
+
+    await auditIntegrityCommand({ repo, json: true });
+    const inspection = JSON.parse(String(mockLog.mock.calls.at(-1)?.[0]));
+    expect(process.exitCode).toBe(1);
+    expect(inspection).toMatchObject({
+      status: 'BROKEN',
+      exists: true,
+      firstBrokenSequence: 0,
+      reason: 'checksum-mismatch',
+    });
+
+    process.exitCode = undefined;
+    await auditIntegrityCommand({
+      repo,
+      json: true,
+      resetBroken: true,
+      acknowledgeDataLoss: true,
+    });
+    const recovery = JSON.parse(String(mockLog.mock.calls.at(-1)?.[0]));
+    expect(process.exitCode).toBeUndefined();
+    expect(recovery).toMatchObject({
+      status: 'BROKEN',
+      archiveSha256: expect.any(String),
+      archiveBytes: originalBytes.length,
+      message: expect.stringContaining('re-ingest'),
+    });
+    expect(readFileSync(recovery.archivePath)).toEqual(originalBytes);
+    expect(JSON.parse(readFileSync(store.eventStorePath, 'utf8'))).toMatchObject({
+      schemaVersion: 2,
+      events: [],
+      integrity: { status: 'VALID' },
+    });
+    expect(JSON.parse(readFileSync(store.projectionPath, 'utf8'))).toMatchObject({
+      schemaVersion: 1,
+      sessions: [],
+      findings: [],
+      bundles: [],
+      lintRuns: [],
+      scopeGuardEvaluations: [],
+    });
+  });
+
+  it('classifies malformed JSON and can reset it with exact-byte archival', async () => {
+    const repo = initRepo();
+    const store = new LocalAuditEventStore(repo);
+    mkdirSync(path.dirname(store.eventStorePath), { recursive: true });
+    const malformedBytes = Buffer.from('{"schemaVersion":', 'utf8');
+    writeFileSync(store.eventStorePath, malformedBytes);
+
+    await auditIntegrityCommand({ repo, json: true });
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(String(mockLog.mock.calls.at(-1)?.[0]))).toMatchObject({
+      status: 'MALFORMED',
+      exists: true,
+    });
+
+    process.exitCode = undefined;
+    await auditIntegrityCommand({
+      repo,
+      json: true,
+      resetBroken: true,
+      acknowledgeDataLoss: true,
+    });
+    const recovery = JSON.parse(String(mockLog.mock.calls.at(-1)?.[0]));
+    expect(process.exitCode).toBeUndefined();
+    expect(readFileSync(recovery.archivePath)).toEqual(malformedBytes);
   });
 });
 

--- a/ontoindex/test/integration/audit-lifecycle-mcp.test.ts
+++ b/ontoindex/test/integration/audit-lifecycle-mcp.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -249,6 +249,44 @@ describe('audit lifecycle MCP integration', () => {
         expect.objectContaining({ findingId: 'finding-a', currentStatus: 'NEEDS-REVERIFY' }),
       ]),
     );
+  });
+
+  it('returns integrity metadata while preserving readable BROKEN-chain reports', async () => {
+    const repo = initRepo();
+    const sessionId = 'session-integrity';
+    const store = new LocalAuditEventStore(repo);
+    await store.createSession(
+      {
+        id: sessionId,
+        targetRepo: path.basename(repo),
+        targetHead: head(repo),
+        sourceHash: 'sha256:integrity',
+        graphIndexId: 'graph-1',
+        verifierVersion: 'verifier-1',
+        sidecarStateHash: 'graph-hash-1',
+        createdAt: '2026-05-17T00:00:00.000Z',
+      },
+      { id: 'evt-session-integrity' },
+    );
+    const state = JSON.parse(readFileSync(store.eventStorePath, 'utf8')) as Record<string, unknown>;
+    const events = state.events as Array<Record<string, unknown>>;
+    events[0].checksum = 'tampered';
+    writeFileSync(store.eventStorePath, JSON.stringify({ ...state, events }));
+
+    for (const [name, params] of [
+      ['gn_audit_replay', { repo, session: sessionId }],
+      ['gn_audit_export', { repo, session: sessionId, format: 'both' }],
+    ] as const) {
+      const report = (await dispatchSuper(name, params, repo)) as Record<string, any>;
+      expect(report.integrity).toMatchObject({ status: 'BROKEN', firstBrokenSequence: 0 });
+      expect(report.ok).not.toBe(false);
+      if (name === 'gn_audit_export') {
+        expect(report.markdown).toContain('Integrity:');
+        expect(report.markdown).toContain('- Status: BROKEN');
+        expect(report.markdown).toContain('- First broken sequence: 0');
+        expect(report.markdown).toContain('- Reason: checksum-mismatch');
+      }
+    }
   });
 
   it('runs scope guard and required test checks during manager review', async () => {

--- a/ontoindex/test/integration/filesystem-walker.test.ts
+++ b/ontoindex/test/integration/filesystem-walker.test.ts
@@ -153,6 +153,25 @@ describe('filesystem-walker', () => {
       }
     });
 
+    it('still scans a crate whose .git directory is a stray empty leftover', async () => {
+      const crateRoot = path.join(tmpDir, 'core-crate');
+      await fs.mkdir(path.join(crateRoot, '.git'), { recursive: true });
+      await fs.mkdir(path.join(crateRoot, 'src'), { recursive: true });
+      await fs.writeFile(
+        path.join(crateRoot, 'src', 'lib.ts'),
+        'export const stillIndexed = true;\n',
+      );
+
+      try {
+        const files = await walkRepositoryPaths(tmpDir);
+        const paths = files.map((file) => file.path.replace(/\\/g, '/'));
+        expect(paths).toContain('core-crate/src/lib.ts');
+        expect(paths.every((p) => !p.includes('/.git/'))).toBe(true);
+      } finally {
+        await fs.rm(crateRoot, { recursive: true, force: true });
+      }
+    });
+
     it('discovers docs in dot-directories while skipping operational dot-directories', async () => {
       const dotDocsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-walker-dotdocs-'));
       await fs.mkdir(path.join(dotDocsDir, '.memory-bank'), { recursive: true });

--- a/ontoindex/test/integration/lbug-pool-generation-swap.test.ts
+++ b/ontoindex/test/integration/lbug-pool-generation-swap.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression: `ontoindex analyze` publishes a new index generation by
+ * repointing the stable `.ontoindex/current` symlink. A pool entry cached by
+ * that stable path kept the handle to the replaced generation, so every later
+ * MCP graph query failed with "Corrupted wal file. Read out invalid WAL record
+ * type." while the same query through a fresh CLI process succeeded.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { inject } from 'vitest';
+import {
+  initLbug,
+  executeQuery,
+  closeLbug,
+  addPoolCloseListener,
+} from '../../src/core/lbug/pool-adapter.js';
+
+const repoId = `test-generation-swap-${Date.now()}`;
+let tmpRoot: string | undefined;
+
+async function copyGeneration(templateDir: string, target: string): Promise<void> {
+  await fs.mkdir(target, { recursive: true });
+  for (const entry of await fs.readdir(templateDir)) {
+    await fs.cp(path.join(templateDir, entry), path.join(target, entry), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+describe('lbug pool generation swap', () => {
+  afterEach(async () => {
+    try {
+      await closeLbug(repoId);
+    } catch {
+      /* best-effort */
+    }
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  it('reopens the database after the current-generation symlink is repointed', async () => {
+    const templateDbPath = inject<'lbugDbPath'>('lbugDbPath');
+    const templateDir = path.dirname(templateDbPath);
+    const dbFileName = path.basename(templateDbPath);
+
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ontoindex-generation-swap-'));
+    const generations = path.join(tmpRoot, 'generations');
+    const genA = path.join(generations, 'gen-a');
+    const genB = path.join(generations, 'gen-b');
+    await copyGeneration(templateDir, genA);
+    await copyGeneration(templateDir, genB);
+
+    const currentLink = path.join(tmpRoot, 'current');
+    await fs.symlink(genA, currentLink, 'dir');
+    const stableDbPath = path.join(currentLink, dbFileName);
+
+    await initLbug(repoId, stableDbPath);
+    const before = await executeQuery(repoId, 'MATCH (f:File) RETURN count(f) AS total');
+    expect(before).toBeDefined();
+
+    const closedRepos: string[] = [];
+    const removeListener = addPoolCloseListener((closedRepoId) => {
+      closedRepos.push(closedRepoId);
+    });
+
+    // Publish a new generation behind the same stable path, exactly as
+    // `ontoindex analyze` does when it swaps `.ontoindex/current`.
+    await fs.rm(currentLink);
+    await fs.symlink(genB, currentLink, 'dir');
+
+    try {
+      await initLbug(repoId, stableDbPath);
+    } finally {
+      removeListener();
+    }
+
+    // The stale handle must be dropped, otherwise queries keep reading the
+    // replaced generation until the process restarts.
+    expect(closedRepos).toContain(repoId);
+
+    const after = await executeQuery(repoId, 'MATCH (f:File) RETURN count(f) AS total');
+    expect(after).toBeDefined();
+  });
+});

--- a/ontoindex/test/unit/analysis-coordinator.test.ts
+++ b/ontoindex/test/unit/analysis-coordinator.test.ts
@@ -2,19 +2,47 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   cancelAnalysisJob,
+  completeAnalysisJob,
   getAnalysisJob,
-  submitAnalysisJob,
+  submitAnalysisJob as submitAnalysisJobCore,
 } from '../../src/core/analysis/analysis-coordinator.js';
-import type { AnalysisJobRecord } from '../../src/core/analysis/analysis-coordinator.js';
+import type {
+  AnalysisJobLifecycleUpdate,
+  AnalysisJobRecord,
+  SubmitAnalysisJobInput,
+} from '../../src/core/analysis/analysis-coordinator.js';
+import type { AnalysisRequestedCapabilities } from '../../src/core/analysis/analysis-publication-receipt.js';
+
+const TEST_HEAD = 'a'.repeat(40);
+const TEST_HEAD_B = 'b'.repeat(40);
+const SOURCE_IDENTITY = `commit:${TEST_HEAD}`;
+const SOURCE_IDENTITY_B = `commit:${TEST_HEAD_B}`;
+const SOURCE_MANIFEST_DIGEST = 'c'.repeat(64);
+const EMBEDDING_MODEL_HASH = 'test-embedding-model';
+const GRAPH_ONLY: AnalysisRequestedCapabilities = {
+  version: 1,
+  graph: true,
+  graphCapabilities: ['symbols'],
+  embeddings: false,
+  embeddingModelHash: null,
+};
+const GRAPH_AND_EMBEDDINGS: AnalysisRequestedCapabilities = {
+  version: 1,
+  graph: true,
+  graphCapabilities: ['symbols'],
+  embeddings: true,
+  embeddingModelHash: EMBEDDING_MODEL_HASH,
+};
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
   delete process.env.ONTOINDEX_ANALYSIS_JOB_RUNNER_PATH;
+  delete process.env.ONTOINDEX_TEST_INHERITED_ANALYSIS_ENV;
   await Promise.all(
     tempDirs
       .splice(0)
@@ -41,68 +69,125 @@ setTimeout(() => {}, 30000);
 
     const first = await submitAnalysisJob({
       repoPath,
-      targetHead: 'head-a',
+      targetHead: TEST_HEAD,
       command: process.execPath,
       args: ['-e', 'process.exit(0)'],
       options: { embeddings: false },
+      requestedCapabilities: GRAPH_ONLY,
+      sourceIdentity: SOURCE_IDENTITY,
     });
     const second = await submitAnalysisJob({
       repoPath,
-      targetHead: 'head-a',
+      targetHead: TEST_HEAD,
       command: process.execPath,
       args: ['-e', 'process.exit(0)'],
       options: { embeddings: false },
+      requestedCapabilities: GRAPH_ONLY,
+      sourceIdentity: SOURCE_IDENTITY,
     });
 
     expect(first.reused).toBe(false);
     expect(second).toMatchObject({ reused: true, job: { id: first.job.id } });
     await waitFor(async () => (await getAnalysisJob(repoPath, first.job.id))?.runnerPid);
     const running = await getAnalysisJob(repoPath, first.job.id);
-    expect(running).toMatchObject({ status: 'running', targetHead: 'head-a' });
+    expect(running).toMatchObject({
+      status: 'running',
+      targetHead: TEST_HEAD,
+      requestedCapabilities: GRAPH_ONLY,
+      sourceIdentity: SOURCE_IDENTITY,
+    });
     if (running?.runnerPid) await terminateProcess(running.runnerPid);
+  });
+
+  it('does not reuse an active job when source identity is unknown', async () => {
+    const repoPath = await makeRepo();
+    const activeJob = makeJob(repoPath, {
+      status: 'running',
+      runnerPid: process.pid,
+      sourceIdentity: undefined as unknown as string,
+      optionsDigest: requestDigest(process.execPath, [], {}, GRAPH_ONLY, undefined),
+    });
+    await writeJobFixture(activeJob);
+
+    await expect(
+      submitAnalysisJob({
+        repoPath,
+        targetHead: TEST_HEAD,
+        command: process.execPath,
+        args: [],
+        options: {},
+        requestedCapabilities: GRAPH_ONLY,
+        sourceIdentity: SOURCE_IDENTITY,
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVE_JOB_CONFLICT', activeJobId: activeJob.id });
+  });
+
+  it('treats a legacy active job without requested capabilities as incompatible', async () => {
+    const repoPath = await makeRepo();
+    const activeJob = makeJob(repoPath, {
+      status: 'running',
+      runnerPid: process.pid,
+      requestedCapabilities: undefined as unknown as AnalysisJobRecord['requestedCapabilities'],
+      optionsDigest: requestDigest(process.execPath, [], {}, GRAPH_ONLY, SOURCE_IDENTITY),
+    });
+    await writeJobFixture(activeJob);
+
+    await expect(
+      submitAnalysisJob({
+        repoPath,
+        targetHead: TEST_HEAD,
+        command: process.execPath,
+        args: [],
+        options: {},
+        requestedCapabilities: GRAPH_ONLY,
+        sourceIdentity: SOURCE_IDENTITY,
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVE_JOB_CONFLICT', activeJobId: activeJob.id });
   });
 
   it('refuses to reuse an active job for a different target snapshot', async () => {
     const repoPath = await makeRepo();
-    await writeJobFixture(
-      makeJob(repoPath, {
-        status: 'queued',
-        runnerPid: undefined,
-        optionsDigest: requestDigest(process.execPath, [], {}),
-      }),
-    );
+    const activeJob = makeJob(repoPath, {
+      status: 'running',
+      runnerPid: process.pid,
+      optionsDigest: requestDigest(process.execPath, [], {}, GRAPH_ONLY, SOURCE_IDENTITY),
+      sourceIdentity: SOURCE_IDENTITY,
+    });
+    await writeJobFixture(activeJob);
 
     await expect(
       submitAnalysisJob({
         repoPath,
-        targetHead: 'head-b',
+        targetHead: TEST_HEAD_B,
         command: process.execPath,
         args: [],
         options: {},
+        sourceIdentity: SOURCE_IDENTITY_B,
       }),
-    ).rejects.toThrow('different analysis request');
+    ).rejects.toMatchObject({ code: 'ACTIVE_JOB_CONFLICT', activeJobId: activeJob.id });
   });
 
   it('refuses to reuse an active job for a different command', async () => {
     const repoPath = await makeRepo();
-    await writeJobFixture(
-      makeJob(repoPath, {
-        status: 'queued',
-        runnerPid: undefined,
-        targetHead: 'head-a',
-        optionsDigest: requestDigest(process.execPath, ['first'], {}),
-      }),
-    );
+    const activeJob = makeJob(repoPath, {
+      status: 'running',
+      runnerPid: process.pid,
+      targetHead: TEST_HEAD,
+      optionsDigest: requestDigest(process.execPath, ['first'], {}, GRAPH_ONLY, SOURCE_IDENTITY),
+      sourceIdentity: SOURCE_IDENTITY,
+    });
+    await writeJobFixture(activeJob);
 
     await expect(
       submitAnalysisJob({
         repoPath,
-        targetHead: 'head-a',
+        targetHead: TEST_HEAD,
         command: process.execPath,
         args: ['second'],
         options: {},
+        sourceIdentity: SOURCE_IDENTITY,
       }),
-    ).rejects.toThrow('different analysis request');
+    ).rejects.toMatchObject({ code: 'ACTIVE_JOB_CONFLICT', activeJobId: activeJob.id });
   });
 
   it('removes expired terminal job records and logs', async () => {
@@ -136,12 +221,118 @@ setTimeout(() => {}, 30000);
     await expect(
       submitAnalysisJob({
         repoPath,
-        targetHead: 'head-a',
+        targetHead: TEST_HEAD,
         command: process.execPath,
         args: [],
         options: {},
+        sourceIdentity: SOURCE_IDENTITY,
       }),
-    ).resolves.toMatchObject({ reused: false, job: { targetHead: 'head-a' } });
+    ).resolves.toMatchObject({
+      reused: false,
+      job: { targetHead: TEST_HEAD, sourceManifestDigest: SOURCE_MANIFEST_DIGEST },
+    });
+  });
+
+  it('removes a newly written job record when active marker acquisition fails', async () => {
+    const repoPath = await makeRepo();
+    const dir = path.join(repoPath, '.ontoindex', 'analysis-jobs');
+    await fs.mkdir(path.join(dir, 'active'), { recursive: true });
+
+    await expect(
+      submitAnalysisJob({
+        repoPath,
+        targetHead: TEST_HEAD,
+        command: process.execPath,
+        args: [],
+        options: {},
+        sourceIdentity: SOURCE_IDENTITY,
+      }),
+    ).rejects.toThrow();
+
+    const entries = await fs.readdir(dir);
+    expect(entries.filter((entry) => entry.endsWith('.json'))).toEqual([]);
+  });
+
+  it('fails closed without replacing a malformed active mutation lock', async () => {
+    const repoPath = await makeRepo();
+    const dir = path.join(repoPath, '.ontoindex', 'analysis-jobs');
+    const lockPath = path.join(dir, 'active.mutation.lock');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(lockPath, '{"version":1');
+
+    await expect(
+      submitAnalysisJob({
+        repoPath,
+        targetHead: TEST_HEAD,
+        command: process.execPath,
+        args: [],
+        options: {},
+        sourceIdentity: SOURCE_IDENTITY,
+      }),
+    ).rejects.toThrow('malformed analysis active mutation lock');
+    await expect(fs.readFile(lockPath, 'utf8')).resolves.toBe('{"version":1');
+  });
+
+  it('reclaims a stale structured recovery sentinel and mutation lock', async () => {
+    const repoPath = await makeRepo();
+    const dir = path.join(repoPath, '.ontoindex', 'analysis-jobs');
+    const lockPath = path.join(dir, 'active.mutation.lock');
+    const deadOwner = {
+      version: 1,
+      token: 'dead-owner',
+      pid: 2_147_483_647,
+      processStartIdentity: 'dead-process',
+      acquiredAt: new Date().toISOString(),
+      repoPath,
+    };
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(lockPath, JSON.stringify(deadOwner));
+    await fs.writeFile(
+      `${lockPath}.recovery`,
+      JSON.stringify({ ...deadOwner, token: 'dead-recovery' }),
+    );
+    const staleClaimPath = `${lockPath}.recovery.claim.${deadOwner.pid}.${Buffer.from(deadOwner.processStartIdentity).toString('hex')}.abandoned`;
+    await fs.writeFile(staleClaimPath, JSON.stringify({ ...deadOwner, token: 'older-recovery' }));
+    process.env.ONTOINDEX_ANALYSIS_JOB_RUNNER_PATH = await writeCompletingRunner(repoPath);
+
+    await expect(
+      submitAnalysisJob({
+        repoPath,
+        targetHead: TEST_HEAD,
+        command: process.execPath,
+        args: [],
+        options: {},
+        sourceIdentity: SOURCE_IDENTITY,
+      }),
+    ).resolves.toMatchObject({ reused: false });
+    await expect(exists(`${lockPath}.recovery`)).resolves.toBe(false);
+    await expect(exists(staleClaimPath)).resolves.toBe(false);
+  });
+
+  it('does not copy current graph metadata into a completed job', async () => {
+    const repoPath = await makeRepo();
+    const job = makeJob(repoPath, { status: 'running' });
+    await writeJobFixture(job);
+    await fs.writeFile(
+      path.join(repoPath, '.ontoindex', 'meta.json'),
+      JSON.stringify({ generationId: 'unproven-current-generation' }),
+    );
+
+    const forgedUpdate: AnalysisJobLifecycleUpdate & {
+      generationId: string;
+      sourceManifestDigest: string;
+    } = {
+      status: 'complete',
+      completedAt: new Date().toISOString(),
+      exitCode: 0,
+      generationId: 'forged-generation',
+      sourceManifestDigest: 'f'.repeat(64),
+    };
+    const completed = await completeAnalysisJob(jobFile(job), forgedUpdate);
+
+    expect(completed.generationId).toBeUndefined();
+    expect(completed.sourceManifestDigest).toBe(SOURCE_MANIFEST_DIGEST);
+    expect(completed.status).toBe('failed');
   });
 
   it('rejects a missing repository without creating it', async () => {
@@ -175,6 +366,31 @@ setTimeout(() => {}, 30000);
     },
   );
 
+  it('refuses cancellation with structured evidence when process identity is unavailable', async () => {
+    const repoPath = await makeRepo();
+    const job = makeJob(repoPath, {
+      runnerPid: process.pid,
+      runnerProcessStartIdentity: undefined,
+    });
+    await writeJobFixture(job);
+    const kill = vi.spyOn(process, 'kill').mockImplementation(((_pid, signal) => {
+      if (signal === 0) return true;
+      return true;
+    }) as typeof process.kill);
+
+    try {
+      await expect(cancelAnalysisJob(repoPath, job.id)).resolves.toMatchObject({
+        cancelled: false,
+        refusal: {
+          reasonCode: 'PROCESS_IDENTITY_UNAVAILABLE',
+        },
+      });
+      expect(kill.mock.calls.some(([, signal]) => signal === 'SIGTERM')).toBe(false);
+    } finally {
+      kill.mockRestore();
+    }
+  });
+
   it('submits after nested untracked content changes without a synchronous source scan', async () => {
     const repoPath = await makeRepo();
     await runGit(repoPath, ['init']);
@@ -192,10 +408,11 @@ await fs.writeFile(file, JSON.stringify(job));
 
     const first = await submitAnalysisJob({
       repoPath,
-      targetHead: 'head-a',
+      targetHead: TEST_HEAD,
       command: process.execPath,
       args: [],
       options: {},
+      sourceIdentity: SOURCE_IDENTITY,
     });
     await waitFor(async () => {
       const job = await getAnalysisJob(repoPath, first.job.id);
@@ -207,14 +424,15 @@ await fs.writeFile(file, JSON.stringify(job));
     await fs.writeFile(nested, 'export const value = 1;\n');
     const second = await submitAnalysisJob({
       repoPath,
-      targetHead: 'head-a',
+      targetHead: TEST_HEAD,
       command: process.execPath,
       args: [],
       options: {},
+      sourceIdentity: SOURCE_IDENTITY,
     });
 
-    expect(first.job.sourceManifestDigest).toBeUndefined();
-    expect(second.job.sourceManifestDigest).toBeUndefined();
+    expect(first.job.sourceManifestDigest).toBe(SOURCE_MANIFEST_DIGEST);
+    expect(second.job.sourceManifestDigest).toBe(SOURCE_MANIFEST_DIGEST);
   });
 
   it('submits when an untracked embedded repository is a dirty status entry', async () => {
@@ -226,13 +444,14 @@ await fs.writeFile(file, JSON.stringify(job));
 
     const result = await submitAnalysisJob({
       repoPath,
-      targetHead: 'head-a',
+      targetHead: TEST_HEAD,
       command: process.execPath,
       args: [],
       options: {},
+      sourceIdentity: SOURCE_IDENTITY,
     });
 
-    expect(result.job.sourceManifestDigest).toBeUndefined();
+    expect(result.job.sourceManifestDigest).toBe(SOURCE_MANIFEST_DIGEST);
   });
 
   it.skipIf(process.platform === 'win32')(
@@ -247,15 +466,64 @@ await fs.writeFile(file, JSON.stringify(job));
 
       const result = await submitAnalysisJob({
         repoPath,
-        targetHead: 'head-a',
+        targetHead: TEST_HEAD,
         command: process.execPath,
         args: [],
         options: {},
+        sourceIdentity: SOURCE_IDENTITY,
       });
 
-      expect(result.job.sourceManifestDigest).toBeUndefined();
+      expect(result.job.sourceManifestDigest).toBe(SOURCE_MANIFEST_DIGEST);
     },
   );
+
+  it('passes validated managed identity to the analyzer and preserves inherited env', async () => {
+    const repoPath = await makeRepo();
+    const receivedPath = path.join(repoPath, 'received-env.json');
+    const analyzerPath = path.join(repoPath, 'capture-env.mjs');
+    await fs.writeFile(
+      analyzerPath,
+      `import fs from 'node:fs/promises';
+await fs.writeFile(process.argv[2], JSON.stringify({
+  inherited: process.env.ONTOINDEX_TEST_INHERITED_ANALYSIS_ENV,
+  jobId: process.env.ONTOINDEX_ANALYSIS_JOB_ID,
+  targetHead: process.env.ONTOINDEX_ANALYSIS_TARGET_HEAD,
+  optionsDigest: process.env.ONTOINDEX_ANALYSIS_OPTIONS_DIGEST,
+  requestedCapabilities: process.env.ONTOINDEX_ANALYSIS_REQUESTED_CAPABILITIES,
+  sourceIdentity: process.env.ONTOINDEX_ANALYSIS_SOURCE_IDENTITY,
+  sourceManifestDigest: process.env.ONTOINDEX_ANALYSIS_SOURCE_MANIFEST_DIGEST,
+  embeddingModelHash: process.env.ONTOINDEX_EMBEDDING_MODEL_HASH,
+}));
+`,
+    );
+    process.env.ONTOINDEX_TEST_INHERITED_ANALYSIS_ENV = 'preserved';
+    process.env.ONTOINDEX_ANALYSIS_JOB_RUNNER_PATH = path.resolve(
+      'dist/core/analysis/analysis-job-runner.js',
+    );
+
+    const submitted = await submitAnalysisJob({
+      repoPath,
+      targetHead: TEST_HEAD,
+      command: process.execPath,
+      args: [analyzerPath, receivedPath],
+      options: { withEmbeddings: true },
+      requestedCapabilities: GRAPH_AND_EMBEDDINGS,
+      sourceIdentity: SOURCE_IDENTITY,
+    });
+    await waitFor(async () => ((await exists(receivedPath)) ? true : undefined));
+    const received = JSON.parse(await fs.readFile(receivedPath, 'utf8')) as Record<string, string>;
+
+    expect(received).toEqual({
+      inherited: 'preserved',
+      jobId: submitted.job.id,
+      targetHead: TEST_HEAD,
+      optionsDigest: submitted.job.optionsDigest,
+      requestedCapabilities: JSON.stringify(GRAPH_AND_EMBEDDINGS),
+      sourceIdentity: SOURCE_IDENTITY,
+      sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+      embeddingModelHash: EMBEDDING_MODEL_HASH,
+    });
+  });
 
   it.skipIf(process.platform === 'win32')(
     'submits when a dirty status entry is a dangling symlink',
@@ -267,17 +535,18 @@ await fs.writeFile(file, JSON.stringify(job));
 
       const result = await submitAnalysisJob({
         repoPath,
-        targetHead: 'head-a',
+        targetHead: TEST_HEAD,
         command: process.execPath,
         args: [],
         options: {},
+        sourceIdentity: SOURCE_IDENTITY,
       });
 
-      expect(result.job.sourceManifestDigest).toBeUndefined();
+      expect(result.job.sourceManifestDigest).toBe(SOURCE_MANIFEST_DIGEST);
     },
   );
 
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(process.platform !== 'linux')(
     'does not report cancellation until the analyzer process group exits',
     async () => {
       const repoPath = await makeRepo();
@@ -299,10 +568,11 @@ setInterval(() => {}, 1000);
 
       const submitted = await submitAnalysisJob({
         repoPath,
-        targetHead: 'head-a',
+        targetHead: TEST_HEAD,
         command: process.execPath,
         args: [analyzerPath],
         options: {},
+        sourceIdentity: `commit:${TEST_HEAD}`,
       });
       const running = await waitFor(async () => {
         const job = await getAnalysisJob(repoPath, submitted.job.id);
@@ -390,8 +660,26 @@ async function terminateProcess(pid: number): Promise<void> {
   }
 }
 
-function requestDigest(command: string, args: string[], options: Record<string, unknown>): string {
-  return createHash('sha256').update(JSON.stringify({ args, command, options })).digest('hex');
+function requestDigest(
+  command: string,
+  args: string[],
+  options: Record<string, unknown>,
+  requestedCapabilities: AnalysisJobRecord['requestedCapabilities'],
+  sourceIdentity: string | undefined,
+  sourceManifestDigest = SOURCE_MANIFEST_DIGEST,
+): string {
+  return createHash('sha256')
+    .update(
+      stableJson({
+        args,
+        command,
+        options,
+        requestedCapabilities,
+        sourceIdentity: sourceIdentity ?? null,
+        sourceManifestDigest,
+      }),
+    )
+    .digest('hex');
 }
 
 function makeJob(repoPath: string, overrides: Partial<AnalysisJobRecord>): AnalysisJobRecord {
@@ -401,15 +689,41 @@ function makeJob(repoPath: string, overrides: Partial<AnalysisJobRecord>): Analy
     id,
     status: 'running',
     repoPath,
-    targetHead: 'head-a',
-    sourceManifestDigest: 'source',
-    optionsDigest: 'options',
+    targetHead: TEST_HEAD,
+    requestedCapabilities: GRAPH_ONLY,
+    sourceIdentity: SOURCE_IDENTITY,
+    sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+    optionsDigest: 'e'.repeat(64),
     command: process.execPath,
     args: [],
     logPath: path.join(repoPath, '.ontoindex', 'analysis-jobs', `${id}.log`),
     createdAt: new Date().toISOString(),
     ...overrides,
   };
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((entry) => stableJson(entry)).join(',')}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+    .join(',')}}`;
+}
+
+function submitAnalysisJob(
+  input: Omit<SubmitAnalysisJobInput, 'requestedCapabilities' | 'sourceManifestDigest'> &
+    Partial<Pick<SubmitAnalysisJobInput, 'requestedCapabilities' | 'sourceManifestDigest'>>,
+) {
+  return submitAnalysisJobCore({
+    ...input,
+    requestedCapabilities: input.requestedCapabilities ?? GRAPH_ONLY,
+    sourceManifestDigest: input.sourceManifestDigest ?? SOURCE_MANIFEST_DIGEST,
+  });
+}
+
+function jobFile(job: AnalysisJobRecord): string {
+  return path.join(job.repoPath, '.ontoindex', 'analysis-jobs', `${job.id}.json`);
 }
 
 async function writeJobFixture(job: AnalysisJobRecord): Promise<void> {

--- a/ontoindex/test/unit/analysis-publication-receipt.test.ts
+++ b/ontoindex/test/unit/analysis-publication-receipt.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  analysisPublicationReceiptPath,
+  MANAGED_ANALYSIS_ENV,
+  parseManagedAnalysisContextFromEnv,
+  readAnalysisPublicationReceipt,
+  writeAnalysisPublicationReceipt,
+  type AnalysisRequestedCapabilities,
+} from '../../src/core/analysis/analysis-publication-receipt.js';
+
+const TARGET_HEAD = 'a'.repeat(40);
+const OPTIONS_DIGEST = 'b'.repeat(64);
+const SOURCE_IDENTITY = `commit:${TARGET_HEAD}`;
+const SOURCE_MANIFEST_DIGEST = 'd'.repeat(64);
+const EMBEDDING_MODEL_HASH = 'test-embedding-model';
+const GRAPH_ONLY: AnalysisRequestedCapabilities = {
+  version: 1,
+  graph: true,
+  graphCapabilities: ['symbols'],
+  embeddings: false,
+  embeddingModelHash: null,
+};
+const GRAPH_AND_EMBEDDINGS: AnalysisRequestedCapabilities = {
+  version: 1,
+  graph: true,
+  graphCapabilities: ['impact', 'symbols'],
+  embeddings: true,
+  embeddingModelHash: EMBEDDING_MODEL_HASH,
+};
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+function managedEnvironment(
+  requestedCapabilities: AnalysisRequestedCapabilities = GRAPH_AND_EMBEDDINGS,
+): NodeJS.ProcessEnv {
+  return {
+    [MANAGED_ANALYSIS_ENV.jobId]: 'managed-job',
+    [MANAGED_ANALYSIS_ENV.targetHead]: TARGET_HEAD,
+    [MANAGED_ANALYSIS_ENV.optionsDigest]: OPTIONS_DIGEST,
+    [MANAGED_ANALYSIS_ENV.sourceIdentity]: SOURCE_IDENTITY,
+    [MANAGED_ANALYSIS_ENV.sourceManifestDigest]: SOURCE_MANIFEST_DIGEST,
+    [MANAGED_ANALYSIS_ENV.requestedCapabilities]: JSON.stringify(requestedCapabilities),
+  };
+}
+
+describe('managed analysis publication receipts', () => {
+  it('parses a complete environment context with a commit-bound source identity', () => {
+    expect(parseManagedAnalysisContextFromEnv(managedEnvironment())).toEqual({
+      jobId: 'managed-job',
+      targetHead: TARGET_HEAD,
+      optionsDigest: OPTIONS_DIGEST,
+      sourceIdentity: SOURCE_IDENTITY,
+      sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+      requestedCapabilities: GRAPH_AND_EMBEDDINGS,
+    });
+  });
+
+  it('rejects an environment context without source identity', () => {
+    const env = managedEnvironment();
+    delete env[MANAGED_ANALYSIS_ENV.sourceIdentity];
+
+    expect(() => parseManagedAnalysisContextFromEnv(env)).toThrow(
+      'Managed analysis context is incomplete.',
+    );
+  });
+
+  it('rejects a source identity that does not match the target HEAD', () => {
+    const env = managedEnvironment();
+    env[MANAGED_ANALYSIS_ENV.sourceIdentity] = `commit:${'c'.repeat(40)}`;
+
+    expect(() => parseManagedAnalysisContextFromEnv(env)).toThrow(
+      'Managed analysis source identity is malformed.',
+    );
+  });
+
+  it.each([
+    ['empty graph capabilities', []],
+    ['duplicate graph capabilities', ['symbols', 'symbols']],
+    ['unsorted graph capabilities', ['symbols', 'impact']],
+    ['unknown graph capabilities', ['query']],
+  ])('rejects %s', (_label, graphCapabilities) => {
+    const env = managedEnvironment();
+    env[MANAGED_ANALYSIS_ENV.requestedCapabilities] = JSON.stringify({
+      ...GRAPH_ONLY,
+      graphCapabilities,
+    });
+
+    expect(() => parseManagedAnalysisContextFromEnv(env)).toThrow(
+      'Managed analysis requested capabilities are malformed.',
+    );
+  });
+
+  it.each([
+    ['missing embedding model identity', true, null],
+    ['blank embedding model identity', true, '   '],
+    ['unexpected embedding model identity', false, EMBEDDING_MODEL_HASH],
+  ])('rejects %s', (_label, embeddings, embeddingModelHash) => {
+    const env = managedEnvironment();
+    env[MANAGED_ANALYSIS_ENV.requestedCapabilities] = JSON.stringify({
+      ...GRAPH_ONLY,
+      embeddings,
+      embeddingModelHash,
+    });
+
+    expect(() => parseManagedAnalysisContextFromEnv(env)).toThrow(
+      'Managed analysis requested capabilities are malformed.',
+    );
+  });
+
+  it('round-trips source identity in a valid publication receipt', async () => {
+    const generationPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'analysis-publication-receipt-'),
+    );
+    tempDirectories.push(generationPath);
+
+    await writeAnalysisPublicationReceipt(generationPath, {
+      version: 1,
+      jobId: 'managed-job',
+      repoPath: path.resolve(generationPath, 'repo'),
+      targetHead: TARGET_HEAD,
+      optionsDigest: OPTIONS_DIGEST,
+      sourceIdentity: SOURCE_IDENTITY,
+      sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+      generationId: 'generation-1',
+      requestedCapabilities: GRAPH_AND_EMBEDDINGS,
+      analyzerContractVersion: 'ontoindex-source-manifest-v1',
+      publishedAt: '2026-08-18T00:00:00.000Z',
+    });
+
+    await expect(
+      readAnalysisPublicationReceipt(generationPath, 'managed-job'),
+    ).resolves.toMatchObject({
+      targetHead: TARGET_HEAD,
+      sourceIdentity: SOURCE_IDENTITY,
+      sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+      requestedCapabilities: GRAPH_AND_EMBEDDINGS,
+    });
+  });
+
+  it.each([
+    ['malformed generation id', { generationId: '../generation' }],
+    ['malformed source manifest digest', { sourceManifestDigest: 'not-a-digest' }],
+  ])('rejects a receipt with %s', async (_label, override) => {
+    const generationPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'analysis-publication-receipt-'),
+    );
+    tempDirectories.push(generationPath);
+
+    await expect(
+      writeAnalysisPublicationReceipt(generationPath, {
+        version: 1,
+        jobId: 'managed-job',
+        repoPath: path.resolve(generationPath, 'repo'),
+        targetHead: TARGET_HEAD,
+        optionsDigest: OPTIONS_DIGEST,
+        sourceIdentity: SOURCE_IDENTITY,
+        sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+        generationId: 'generation-1',
+        requestedCapabilities: GRAPH_ONLY,
+        analyzerContractVersion: 'ontoindex-source-manifest-v1',
+        publishedAt: '2026-08-18T00:00:00.000Z',
+        ...override,
+      }),
+    ).rejects.toThrow(/malformed/);
+  });
+
+  it('fails closed when a stored receipt source identity is changed', async () => {
+    const generationPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'analysis-publication-receipt-'),
+    );
+    tempDirectories.push(generationPath);
+    const receiptPath = analysisPublicationReceiptPath(generationPath, 'managed-job');
+    await fs.mkdir(path.dirname(receiptPath), { recursive: true });
+    await fs.writeFile(
+      receiptPath,
+      JSON.stringify({
+        version: 1,
+        jobId: 'managed-job',
+        repoPath: path.resolve(generationPath, 'repo'),
+        targetHead: TARGET_HEAD,
+        optionsDigest: OPTIONS_DIGEST,
+        sourceIdentity: `commit:${'c'.repeat(40)}`,
+        sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+        generationId: 'generation-1',
+        requestedCapabilities: GRAPH_ONLY,
+        analyzerContractVersion: 'ontoindex-source-manifest-v1',
+        publishedAt: '2026-08-18T00:00:00.000Z',
+      }),
+      'utf8',
+    );
+
+    await expect(readAnalysisPublicationReceipt(generationPath, 'managed-job')).resolves.toBeNull();
+  });
+});

--- a/ontoindex/test/unit/audit-dispatch.test.ts
+++ b/ontoindex/test/unit/audit-dispatch.test.ts
@@ -17,6 +17,7 @@ import type {
   AuditSession,
 } from '../../src/core/audit-lifecycle/audit-session.js';
 import { gnAuditSessionDispatch } from '../../src/mcp/super/audit-session-tools.js';
+import { gnDispatchPrompt } from '../../src/mcp/super/audit-advanced.js';
 import {
   buildTestGapReport,
   gnTestGap,
@@ -280,6 +281,98 @@ describe('manager audit dispatch wrapper', () => {
     expect(result.duplicateOnlyChildren).toBe(true);
   });
 
+  it('refuses dispatch when the event chain is broken, including persist=false', async () => {
+    const store = await seedDispatchBundle(repo);
+    await createAuditSessionLockFromStore({
+      repoRoot: repo,
+      sessionId: 'session-1',
+      graphHash: 'sha256:sidecar',
+      ontoindexVersion: '1.0.0',
+      store,
+    });
+    const statePath = store.eventStorePath;
+    const state = JSON.parse(await fs.readFile(statePath, 'utf8')) as Record<string, unknown>;
+    const events = state.events as Array<Record<string, unknown>>;
+    events[0].checksum = 'tampered';
+    await fs.writeFile(statePath, JSON.stringify({ ...state, events }));
+
+    await expect(
+      gnDispatchPrompt(repo, { session: 'session-1', bundleId: 'bundle-1', persist: false }),
+    ).rejects.toMatchObject({
+      code: 'ERR_AUDIT_CHAIN_BROKEN',
+      firstBrokenSequence: 0,
+      reason: 'checksum-mismatch',
+    });
+
+    const result = await gnAuditSessionDispatch(repo, {
+      session: 'session-1',
+      bundleId: 'bundle-1',
+      persist: false,
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'ERR_AUDIT_CHAIN_BROKEN',
+      firstBrokenSequence: 0,
+      reason: 'checksum-mismatch',
+    });
+  });
+
+  it('refuses dispatch for an unverifiable legacy chain', async () => {
+    const store = await seedDispatchBundle(repo);
+    await createAuditSessionLockFromStore({
+      repoRoot: repo,
+      sessionId: 'session-1',
+      graphHash: 'sha256:sidecar',
+      ontoindexVersion: '1.0.0',
+      store,
+    });
+    const state = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    const events = (state.events as Array<Record<string, unknown>>).map(
+      ({ sequence, checksum, previousChecksum, ...event }) => event,
+    );
+    await fs.writeFile(store.eventStorePath, JSON.stringify({ schemaVersion: 1, events }));
+    await expect(
+      gnDispatchPrompt(repo, { session: 'session-1', bundleId: 'bundle-1', persist: false }),
+    ).rejects.toMatchObject({ code: 'ERR_AUDIT_CHAIN_BROKEN' });
+
+    const managerResult = await gnAuditSessionDispatch(repo, {
+      session: 'session-1',
+      bundleId: 'bundle-1',
+      persist: false,
+    });
+    expect(managerResult).toMatchObject({
+      ok: false,
+      code: 'ERR_AUDIT_CHAIN_BROKEN',
+      reason: 'legacy-unverified-chain',
+    });
+  });
+
+  it('refuses a tampered chain downgraded to schema v1', async () => {
+    const store = await seedDispatchBundle(repo);
+    await createAuditSessionLockFromStore({
+      repoRoot: repo,
+      sessionId: 'session-1',
+      graphHash: 'sha256:sidecar',
+      ontoindexVersion: '1.0.0',
+      store,
+    });
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    const events = raw.events as Array<Record<string, unknown>>;
+    events[0].sessionId = 'tampered-session';
+    await fs.writeFile(store.eventStorePath, JSON.stringify({ ...raw, schemaVersion: 1, events }));
+
+    await expect(store.load()).resolves.toMatchObject({ integrity: { status: 'BROKEN' } });
+    await expect(
+      gnDispatchPrompt(repo, { session: 'session-1', bundleId: 'bundle-1', persist: false }),
+    ).rejects.toMatchObject({ code: 'ERR_AUDIT_CHAIN_BROKEN' });
+  });
+
   it('reports unexpected files, symbols, impacts, and missing tests in gn_verify_diff', async () => {
     const result = await gnVerifyDiff(repo, {
       repo,
@@ -406,6 +499,78 @@ describe('manager audit dispatch wrapper', () => {
     expect(result.testGap).toMatchObject({ status: 'FAIL' });
   });
 });
+
+async function seedDispatchBundle(repo: string): Promise<LocalAuditEventStore> {
+  const store = new LocalAuditEventStore(repo);
+  const targetHead = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: repo,
+    encoding: 'utf8',
+  }).trim();
+  await store.createSession(
+    {
+      id: 'session-1',
+      targetRepo: 'repo-a',
+      targetHead,
+      sourceHash: 'sha256:source',
+      graphIndexId: 'index-1',
+      verifierVersion: 'verifier-1',
+      sidecarStateHash: 'sha256:sidecar',
+      createdAt: '2026-05-17T00:00:00.000Z',
+    },
+    { id: 'evt-session-dispatch' },
+  );
+  await store.createFindingCandidate(
+    {
+      id: 'finding-a',
+      sessionId: 'session-1',
+      title: 'Dispatch finding',
+      fingerprint: 'fp-dispatch',
+      status: 'OPEN',
+      metadata: {
+        files: ['src/app.ts'],
+        symbols: ['run'],
+        tests: ['test/app.test.ts'],
+        writeSet: ['src/app.ts'],
+      },
+    },
+    { id: 'evt-candidate-dispatch' },
+  );
+  await store.appendEvent({
+    id: 'evt-verify-dispatch',
+    type: 'FindingVerified',
+    occurredAt: '2026-05-17T00:00:02.000Z',
+    sessionId: 'session-1',
+    findingId: 'finding-a',
+    verification: {
+      verifiedAt: '2026-05-17T00:00:02.000Z',
+      status: 'OPEN',
+      evidence: [sessionEvidence(targetHead)],
+      reasonCodes: ['fresh-positive-evidence'],
+      verifierVersion: 'verifier-1',
+    },
+  });
+  await store.appendEvent({
+    id: 'evt-bundle-dispatch',
+    type: 'FindingBundled',
+    occurredAt: '2026-05-17T00:00:03.000Z',
+    sessionId: 'session-1',
+    bundleId: 'bundle-1',
+    bundle: {
+      id: 'bundle-1',
+      sessionId: 'session-1',
+      findingIds: ['finding-a'],
+      status: 'CREATED',
+      createdAt: '2026-05-17T00:00:03.000Z',
+      metadata: {
+        files: ['src/app.ts'],
+        symbols: ['run'],
+        tests: ['test/app.test.ts'],
+        writeSet: ['src/app.ts'],
+      },
+    },
+  });
+  return store;
+}
 
 function bundle(
   id: string,

--- a/ontoindex/test/unit/audit-event-store.test.ts
+++ b/ontoindex/test/unit/audit-event-store.test.ts
@@ -5,11 +5,14 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  AUDIT_EVENT_STORE_GENESIS_PREVIOUS_CHECKSUM,
   AUDIT_EVENT_STORE_SCHEMA_VERSION,
   LocalAuditEventStore,
   getAuditEventStorePath,
   getAuditProjectionPath,
+  inspectAuditEventStoreRaw,
   loadAuditEventStoreState,
+  recoverAuditEventStore,
   rebuildAuditProjectionFile,
   saveAuditEventStoreState,
   type AuditEvent,
@@ -66,6 +69,7 @@ describe('audit event store', () => {
     await expect(loadAuditEventStoreState(store.eventStorePath)).resolves.toEqual({
       schemaVersion: AUDIT_EVENT_STORE_SCHEMA_VERSION,
       events: [],
+      integrity: { status: 'VALID' },
     });
   });
 
@@ -74,7 +78,7 @@ describe('audit event store', () => {
 
     const rawStore = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
     expect(rawStore).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       events: [
         {
           id: 'evt-1',
@@ -266,6 +270,10 @@ describe('audit event store', () => {
     const state = await store.load();
     expect(state.events).toHaveLength(6);
     expect(new Set(state.events.map((event) => event.id)).size).toBe(6);
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    expect(raw.events.map((event: { sequence: number }) => event.sequence)).toEqual([
+      0, 1, 2, 3, 4, 5,
+    ]);
   });
 
   it('rejects corrupted JSON and duplicate event ids', async () => {
@@ -276,7 +284,7 @@ describe('audit event store', () => {
     await fs.writeFile(
       store.eventStorePath,
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         events: [
           { ...verifiedEvent(), id: 'dup' },
           { ...verifiedEvent(), id: 'dup' },
@@ -285,6 +293,322 @@ describe('audit event store', () => {
       'utf8',
     );
     await expect(store.load()).rejects.toThrow('duplicate audit event id: dup');
+  });
+
+  it('writes deterministic v2 integrity envelopes with the genesis link', async () => {
+    await store.createSession(sessionInput, { id: 'evt-1' });
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    expect(raw.schemaVersion).toBe(2);
+    expect(raw.events[0]).toMatchObject({
+      sequence: 0,
+      previousChecksum: AUDIT_EVENT_STORE_GENESIS_PREVIOUS_CHECKSUM,
+    });
+    expect(raw.events[0].checksum).toMatch(/^[a-f0-9]{64}$/);
+    const checksum = raw.events[0].checksum;
+    await saveAuditEventStoreState(store.eventStorePath, await store.load());
+    const saved = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    expect(saved.events[0].checksum).toBe(checksum);
+  });
+
+  it('reports broken v2 chains without laundering them on save', async () => {
+    await store.createSession(sessionInput, { id: 'evt-1' });
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    raw.events[0].session.targetHead = 'mutated';
+    await fs.writeFile(store.eventStorePath, JSON.stringify(raw), 'utf8');
+    await expect(store.load()).resolves.toMatchObject({ integrity: { status: 'BROKEN' } });
+    await expect(
+      saveAuditEventStoreState(store.eventStorePath, await store.load()),
+    ).rejects.toThrow('cannot save audit event store with broken on-disk chain');
+  });
+
+  it('fails closed when a schema-v2 store has integrity envelopes stripped', async () => {
+    await store.createSession(sessionInput, { id: 'evt-1' });
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    delete raw.events[0].sequence;
+    delete raw.events[0].previousChecksum;
+    delete raw.events[0].checksum;
+    await fs.writeFile(store.eventStorePath, JSON.stringify(raw), 'utf8');
+
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: { status: 'BROKEN', reason: 'missing-integrity-envelope' },
+    });
+    await expect(
+      saveAuditEventStoreState(store.eventStorePath, await store.load()),
+    ).rejects.toThrow('cannot save audit event store with broken on-disk chain');
+
+    const after = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    expect(after.events[0].sequence).toBeUndefined();
+    expect(after.events[0].checksum).toBeUndefined();
+  });
+
+  it('reads v1 as legacy and refuses to migrate it in place', async () => {
+    await fs.mkdir(path.dirname(store.eventStorePath), { recursive: true });
+    await fs.writeFile(
+      store.eventStorePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        events: [
+          {
+            id: 'legacy-1',
+            type: 'AuditIngested',
+            occurredAt: sessionInput.createdAt,
+            sessionId: sessionInput.id,
+            session: sessionInput,
+          },
+        ],
+      }),
+      'utf8',
+    );
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: { status: 'LEGACY_UNVERIFIED' },
+    });
+    const before = await fs.readFile(store.eventStorePath);
+    await expect(
+      store.createFindingCandidate(
+        { id: 'finding-new', sessionId: 'session-1', title: 'Finding', fingerprint: 'fp-new' },
+        { id: 'evt-new' },
+      ),
+    ).rejects.toThrow('cannot write to an unverified legacy audit event store');
+    expect(await fs.readFile(store.eventStorePath)).toEqual(before);
+  });
+
+  it('does not let envelope stripping plus an append launder tampered history', async () => {
+    await store.createSession(sessionInput, { id: 'evt-1' });
+    await store.createFindingCandidate(
+      { id: 'finding-1', sessionId: 'session-1', title: 'Original', fingerprint: 'fp-1' },
+      { id: 'evt-2', occurredAt: '2026-05-17T00:00:01.000Z' },
+    );
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    raw.events[1].finding.title = 'TAMPERED';
+    const stripped = raw.events.map(
+      ({ sequence, checksum, previousChecksum, ...event }: Record<string, unknown>) => event,
+    );
+    await fs.writeFile(
+      store.eventStorePath,
+      JSON.stringify({ schemaVersion: 1, events: stripped }),
+      'utf8',
+    );
+
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: { status: 'LEGACY_UNVERIFIED' },
+    });
+    await expect(
+      store.appendEvent({
+        id: 'evt-lint',
+        type: 'AuditLinted',
+        occurredAt: '2026-05-17T00:00:09.000Z',
+        sessionId: 'session-1',
+        status: 'passed',
+        findingIds: ['finding-1'],
+        warnings: [],
+      }),
+    ).rejects.toThrow('cannot write to an unverified legacy audit event store');
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: { status: 'LEGACY_UNVERIFIED' },
+    });
+  });
+
+  it('archives an unverified legacy store into a fresh empty chain', async () => {
+    await fs.mkdir(path.dirname(store.eventStorePath), { recursive: true });
+    await fs.writeFile(
+      store.eventStorePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        events: [
+          {
+            id: 'legacy-1',
+            type: 'AuditIngested',
+            occurredAt: sessionInput.createdAt,
+            sessionId: sessionInput.id,
+            session: sessionInput,
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const original = await fs.readFile(store.eventStorePath);
+
+    const recovery = await recoverAuditEventStore(store.eventStorePath, store.projectionPath);
+
+    expect(await fs.readFile(recovery.archivePath)).toEqual(original);
+    await expect(store.load()).resolves.toMatchObject({
+      events: [],
+      integrity: { status: 'VALID' },
+    });
+  });
+
+  it('binds the legacy boundary into every checksum', async () => {
+    await store.createSession(sessionInput, { id: 'evt-1' });
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    expect(
+      raw.events.every((event: Record<string, unknown>) => event.legacyPrefixLength === undefined),
+    ).toBe(true);
+    raw.legacyPrefixLength = 1;
+    await fs.writeFile(store.eventStorePath, JSON.stringify(raw), 'utf8');
+
+    // legacyPrefixLength participates in every checksum, so injecting a boundary
+    // cannot silently reclassify already-signed events.
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: { status: 'BROKEN', firstBrokenSequence: 0, reason: 'checksum-mismatch' },
+    });
+  });
+
+  it('rejects an out-of-range legacy boundary as broken integrity', async () => {
+    await store.createSession(sessionInput, { id: 'evt-1' });
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    raw.legacyPrefixLength = 2;
+    await fs.writeFile(store.eventStorePath, JSON.stringify(raw), 'utf8');
+
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: {
+        status: 'BROKEN',
+        firstBrokenSequence: 0,
+        reason: 'invalid-legacy-prefix-length',
+      },
+    });
+  });
+
+  it('does not let a schema downgrade launder a broken chain', async () => {
+    await store.createSession(sessionInput, { id: 'evt-1' });
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    raw.events[0].session.targetHead = 'mutated';
+    raw.schemaVersion = 1;
+    await fs.writeFile(store.eventStorePath, JSON.stringify(raw), 'utf8');
+
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: { status: 'BROKEN', reason: 'checksum-mismatch' },
+    });
+  });
+
+  it('normalizes every event type idempotently across a save/load round trip', async () => {
+    await seedAllEventTypes(store);
+    const first = await store.load();
+    await saveAuditEventStoreState(store.eventStorePath, first);
+    const second = await store.load();
+
+    expect(second.events).toEqual(first.events);
+    expect(second.integrity).toEqual({ status: 'VALID' });
+  });
+
+  it('reports insertion at the first affected sequence', async () => {
+    await seedVerifiedFinding(store);
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    raw.events.splice(1, 0, { ...raw.events[2], id: 'evt-inserted' });
+    await fs.writeFile(store.eventStorePath, JSON.stringify(raw), 'utf8');
+
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: { status: 'BROKEN', firstBrokenSequence: 1 },
+    });
+  });
+
+  it('reports reordering at the first affected sequence', async () => {
+    await seedVerifiedFinding(store);
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    raw.events = [raw.events[1], raw.events[0], raw.events[2]];
+    await fs.writeFile(store.eventStorePath, JSON.stringify(raw), 'utf8');
+
+    await expect(store.load()).resolves.toMatchObject({
+      integrity: { status: 'BROKEN', firstBrokenSequence: 0 },
+    });
+  });
+
+  it('still reports the retained chain valid after a tail deletion', async () => {
+    await seedVerifiedFinding(store);
+    const raw = JSON.parse(await fs.readFile(store.eventStorePath, 'utf8'));
+    raw.events.pop();
+    await fs.writeFile(store.eventStorePath, JSON.stringify(raw), 'utf8');
+
+    // Documents the accepted limitation: deleting a valid tail is undetectable
+    // without an independent trust anchor.
+    await expect(store.load()).resolves.toMatchObject({ integrity: { status: 'VALID' } });
+  });
+
+  it('refuses a direct save of an unverified legacy state', async () => {
+    await fs.mkdir(path.dirname(store.eventStorePath), { recursive: true });
+    await fs.writeFile(
+      store.eventStorePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        events: [
+          {
+            id: 'legacy-1',
+            type: 'AuditIngested',
+            occurredAt: sessionInput.createdAt,
+            sessionId: sessionInput.id,
+            session: sessionInput,
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const before = await fs.readFile(store.eventStorePath);
+
+    await expect(
+      saveAuditEventStoreState(store.eventStorePath, await store.load()),
+    ).rejects.toThrow('cannot write to an unverified legacy audit event store');
+    expect(await fs.readFile(store.eventStorePath)).toEqual(before);
+  });
+
+  it('refuses to overwrite malformed on-disk bytes through save', async () => {
+    await fs.mkdir(path.dirname(store.eventStorePath), { recursive: true });
+    const bytes = Buffer.from('{malformed', 'utf8');
+    await fs.writeFile(store.eventStorePath, bytes);
+
+    await expect(
+      saveAuditEventStoreState(store.eventStorePath, {
+        schemaVersion: AUDIT_EVENT_STORE_SCHEMA_VERSION,
+        events: [],
+      }),
+    ).rejects.toThrow('cannot save over malformed audit event store');
+    expect(await fs.readFile(store.eventStorePath)).toEqual(bytes);
+  });
+
+  it('inspects malformed raw bytes and archives them into a fresh empty chain', async () => {
+    await fs.mkdir(path.dirname(store.eventStorePath), { recursive: true });
+    const bytes = Buffer.from('{malformed', 'utf8');
+    await fs.writeFile(store.eventStorePath, bytes);
+    const inspected = await inspectAuditEventStoreRaw(store.eventStorePath);
+    expect(inspected.parseError).toBeTruthy();
+    const recovery = await recoverAuditEventStore(store.eventStorePath, store.projectionPath);
+    expect(recovery.archiveBytes).toBe(bytes.length);
+    expect(await fs.readFile(recovery.archivePath)).toEqual(bytes);
+    await expect(store.load()).resolves.toMatchObject({
+      events: [],
+      integrity: { status: 'VALID' },
+    });
+  });
+
+  it('refuses recovery for a healthy store without changing its bytes', async () => {
+    await store.createSession(sessionInput, { id: 'evt-1' });
+    const before = await fs.readFile(store.eventStorePath);
+
+    await expect(
+      recoverAuditEventStore(store.eventStorePath, store.projectionPath),
+    ).rejects.toThrow('cannot recover audit event store with VALID integrity');
+    expect(await fs.readFile(store.eventStorePath)).toEqual(before);
+  });
+
+  itOnLockFriendlyFs('uses the append lock during recovery', async () => {
+    await fs.mkdir(path.dirname(store.eventStorePath), { recursive: true });
+    const bytes = Buffer.from('{malformed', 'utf8');
+    await fs.writeFile(store.eventStorePath, bytes);
+    const lockPath = path.join(
+      path.dirname(store.eventStorePath),
+      `.${path.basename(store.eventStorePath)}.update.lock`,
+    );
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ ownerId: 'active-owner', acquiredAt: new Date().toISOString() }),
+      'utf8',
+    );
+
+    await expect(
+      recoverAuditEventStore(store.eventStorePath, store.projectionPath, {
+        maxAttempts: 1,
+        staleLockMs: 60_000,
+      }),
+    ).rejects.toThrow('timed out acquiring audit event store update lock');
+    expect(await fs.readFile(store.eventStorePath)).toEqual(bytes);
   });
 
   it('does not mutate existing event history when appending', async () => {
@@ -322,4 +646,86 @@ function verifiedEvent(): AuditEvent {
       verifierVersion: 'verifier-1',
     },
   };
+}
+
+async function seedVerifiedFinding(target: LocalAuditEventStore): Promise<void> {
+  await target.createSession(sessionInput, { id: 'evt-1' });
+  await target.createFindingCandidate(
+    { id: 'finding-1', sessionId: 'session-1', title: 'Finding', fingerprint: 'fp-1' },
+    { id: 'evt-2', occurredAt: '2026-05-17T00:00:01.000Z' },
+  );
+  await target.appendEvent(verifiedEvent());
+}
+
+// Covers all nine AuditEvent variants, including a non-UTC timestamp, an
+// unsorted array with duplicates, and an unknown field on the input.
+async function seedAllEventTypes(target: LocalAuditEventStore): Promise<void> {
+  await target.createSession(sessionInput, { id: 'evt-1' });
+  await target.createFindingCandidate(
+    { id: 'finding-1', sessionId: 'session-1', title: 'Finding', fingerprint: 'fp-1' },
+    { id: 'evt-2', occurredAt: '2026-05-17T02:00:01.000+02:00' },
+  );
+  await target.appendEvent(verifiedEvent());
+  await target.appendEvent({
+    id: 'evt-4',
+    type: 'FindingStatusChanged',
+    occurredAt: '2026-05-17T00:00:03.000Z',
+    sessionId: 'session-1',
+    findingId: 'finding-1',
+    status: 'RESOLVED-ALREADY',
+    reason: 'negative evidence still holds',
+  } as AuditEvent);
+  await target.appendEvent({
+    id: 'evt-5',
+    type: 'FindingTombstoned',
+    occurredAt: '2026-05-17T00:00:04.000Z',
+    sessionId: 'session-1',
+    findingId: 'finding-1',
+    tombstone: {
+      tombstonedAt: '2026-05-17T00:00:04.000Z',
+      reason: 'fixed before ingest',
+      evidence: [evidence],
+    },
+  });
+  await target.appendEvent({
+    id: 'evt-6',
+    type: 'FindingBundled',
+    occurredAt: '2026-05-17T00:00:05.000Z',
+    sessionId: 'session-1',
+    bundleId: 'bundle-1',
+    bundle: {
+      id: 'bundle-1',
+      sessionId: 'session-1',
+      findingIds: ['finding-1'],
+      status: 'CREATED',
+      createdAt: '2026-05-17T00:00:05.000Z',
+      metadata: {},
+    },
+  });
+  await target.appendEvent({
+    id: 'evt-7',
+    type: 'BundleDispatched',
+    occurredAt: '2026-05-17T00:00:06.000Z',
+    sessionId: 'session-1',
+    bundleId: 'bundle-1',
+    dispatchedAt: '2026-05-17T00:00:06.000Z',
+    metadata: { worker: 'external', unknownField: 'preserved' },
+  });
+  await target.appendEvent({
+    id: 'evt-8',
+    type: 'AuditLinted',
+    occurredAt: '2026-05-17T00:00:07.000Z',
+    sessionId: 'session-1',
+    status: 'passed',
+    findingIds: ['finding-1', 'finding-1', 'finding-0'],
+    warnings: [],
+  });
+  await target.appendEvent({
+    id: 'evt-9',
+    type: 'ScopeGuardEvaluated',
+    occurredAt: '2026-05-17T00:00:08.000Z',
+    sessionId: 'session-1',
+    status: 'passed',
+    metadata: { changedFiles: [] },
+  });
 }

--- a/ontoindex/test/unit/repo-manager.test.ts
+++ b/ontoindex/test/unit/repo-manager.test.ts
@@ -18,9 +18,13 @@ import {
   listRegisteredRepos,
   RegistryNameCollisionError,
   activateIndexGeneration,
+  activateIndexGenerationTransaction,
   createIndexGeneration,
   loadRepo,
+  readActiveGenerationMeta,
+  publishIndexGenerationTransaction,
   resolveActiveIndexGeneration,
+  rollbackIndexGenerationActivation,
   type RepoMeta,
 } from '../../src/storage/repo-manager.js';
 import { parseRepoNameFromUrl, getInferredRepoName } from '../../src/storage/git.js';
@@ -61,6 +65,15 @@ describe('getStoragePaths', () => {
 });
 
 describe('index generations', () => {
+  async function writeGenerationFiles(
+    generation: Awaited<ReturnType<typeof createIndexGeneration>>,
+    content: string,
+  ): Promise<void> {
+    await fs.writeFile(generation.lbugPath, content);
+    await fs.writeFile(generation.metaPath, '{}');
+    await fs.writeFile(generation.snapshotPath, '{}');
+  }
+
   it('atomically changes the active generation while old files remain immutable', async () => {
     const temp = await createTempDir('ontoindex-generations-');
     const storagePath = path.join(temp.dbPath, '.ontoindex');
@@ -125,6 +138,196 @@ describe('index generations', () => {
     }
   });
 
+  it('restores the exact previous active generation after a fenced rollback', async () => {
+    const temp = await createTempDir('ontoindex-generation-rollback-');
+    const storagePath = path.join(temp.dbPath, '.ontoindex');
+    try {
+      const first = await createIndexGeneration(storagePath, 'generation-1');
+      await writeGenerationFiles(first, 'first');
+      await activateIndexGeneration(storagePath, first);
+
+      const second = await createIndexGeneration(storagePath, 'generation-2');
+      await writeGenerationFiles(second, 'second');
+      const activation = await activateIndexGenerationTransaction(storagePath, second);
+
+      await rollbackIndexGenerationActivation(
+        storagePath,
+        activation.activeGeneration.generationId,
+        activation.previousGeneration,
+      );
+
+      expect((await resolveActiveIndexGeneration(storagePath))?.generationId).toBe('generation-1');
+      expect(await fs.readFile(path.join(storagePath, 'lbug'), 'utf8')).toBe('first');
+      await expect(fs.readFile(activation.activeGeneration.lbugPath, 'utf8')).resolves.toBe(
+        'second',
+      );
+    } finally {
+      await temp.cleanup();
+    }
+  });
+
+  it('removes the active pointer when rolling back the first generation', async () => {
+    const temp = await createTempDir('ontoindex-generation-rollback-empty-');
+    const storagePath = path.join(temp.dbPath, '.ontoindex');
+    try {
+      const first = await createIndexGeneration(storagePath, 'generation-1');
+      await writeGenerationFiles(first, 'first');
+      const activation = await activateIndexGenerationTransaction(storagePath, first);
+
+      await rollbackIndexGenerationActivation(
+        storagePath,
+        activation.activeGeneration.generationId,
+        activation.previousGeneration,
+      );
+
+      await expect(resolveActiveIndexGeneration(storagePath)).resolves.toBeNull();
+      await expect(fs.lstat(path.join(storagePath, 'current'))).rejects.toThrow();
+      await expect(fs.lstat(path.join(storagePath, 'lbug'))).rejects.toThrow();
+      await expect(fs.readFile(activation.activeGeneration.lbugPath, 'utf8')).resolves.toBe(
+        'first',
+      );
+    } finally {
+      await temp.cleanup();
+    }
+  });
+
+  it('refuses rollback after another generation becomes active', async () => {
+    const temp = await createTempDir('ontoindex-generation-rollback-race-');
+    const storagePath = path.join(temp.dbPath, '.ontoindex');
+    try {
+      const first = await createIndexGeneration(storagePath, 'generation-1');
+      await writeGenerationFiles(first, 'first');
+      await activateIndexGeneration(storagePath, first);
+
+      const second = await createIndexGeneration(storagePath, 'generation-2');
+      await writeGenerationFiles(second, 'second');
+      const activation = await activateIndexGenerationTransaction(storagePath, second);
+
+      const third = await createIndexGeneration(storagePath, 'generation-3');
+      await writeGenerationFiles(third, 'third');
+      await activateIndexGeneration(storagePath, third);
+
+      await expect(
+        rollbackIndexGenerationActivation(
+          storagePath,
+          activation.activeGeneration.generationId,
+          activation.previousGeneration,
+        ),
+      ).rejects.toThrow('Refusing index generation rollback');
+      expect((await resolveActiveIndexGeneration(storagePath))?.generationId).toBe('generation-3');
+      expect(await fs.readFile(path.join(storagePath, 'lbug'), 'utf8')).toBe('third');
+    } finally {
+      await temp.cleanup();
+    }
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'refuses rollback when the previous generation was replaced by a symlink',
+    async () => {
+      const temp = await createTempDir('ontoindex-generation-rollback-symlink-');
+      const storagePath = path.join(temp.dbPath, '.ontoindex');
+      const externalPath = path.join(temp.dbPath, 'external-generation');
+      try {
+        const first = await createIndexGeneration(storagePath, 'generation-1');
+        await writeGenerationFiles(first, 'first');
+        await activateIndexGeneration(storagePath, first);
+
+        const second = await createIndexGeneration(storagePath, 'generation-2');
+        await writeGenerationFiles(second, 'second');
+        const activation = await activateIndexGenerationTransaction(storagePath, second);
+
+        await fs.mkdir(externalPath, { recursive: true });
+        await fs.rm(activation.previousGeneration!.generationPath, {
+          recursive: true,
+          force: true,
+        });
+        await fs.symlink(externalPath, activation.previousGeneration!.generationPath, 'dir');
+
+        await expect(
+          rollbackIndexGenerationActivation(
+            storagePath,
+            activation.activeGeneration.generationId,
+            activation.previousGeneration,
+          ),
+        ).rejects.toThrow('must not be a symbolic link');
+        expect((await resolveActiveIndexGeneration(storagePath))?.generationId).toBe(
+          'generation-2',
+        );
+      } finally {
+        await temp.cleanup();
+      }
+    },
+  );
+
+  it('serializes another activation until a publication commit finishes', async () => {
+    const temp = await createTempDir('ontoindex-generation-publication-lock-');
+    const storagePath = path.join(temp.dbPath, '.ontoindex');
+    try {
+      const first = await createIndexGeneration(storagePath, 'generation-1');
+      await writeGenerationFiles(first, 'first');
+      const second = await createIndexGeneration(storagePath, 'generation-2');
+      await writeGenerationFiles(second, 'second');
+
+      let releaseCommit!: () => void;
+      const commitGate = new Promise<void>((resolve) => {
+        releaseCommit = resolve;
+      });
+      let commitStarted!: () => void;
+      const commitStart = new Promise<void>((resolve) => {
+        commitStarted = resolve;
+      });
+      const publication = publishIndexGenerationTransaction(storagePath, first, async () => {
+        commitStarted();
+        await commitGate;
+      });
+      await commitStart;
+
+      let secondActivated = false;
+      const secondActivation = activateIndexGeneration(storagePath, second).then(() => {
+        secondActivated = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+
+      expect(secondActivated).toBe(false);
+      expect((await resolveActiveIndexGeneration(storagePath))?.generationId).toBe('generation-1');
+
+      releaseCommit();
+      await publication;
+      await secondActivation;
+      expect((await resolveActiveIndexGeneration(storagePath))?.generationId).toBe('generation-2');
+    } finally {
+      await temp.cleanup();
+    }
+  });
+
+  it('surfaces failure to remove the owned generation pointer lock', async () => {
+    const temp = await createTempDir('ontoindex-generation-lock-release-');
+    const storagePath = path.join(temp.dbPath, '.ontoindex');
+    const lockPath = path.join(storagePath, 'current.mutation.lock');
+    try {
+      const generation = await createIndexGeneration(storagePath, 'generation-1');
+      await writeGenerationFiles(generation, 'first');
+      const unlink = fs.unlink.bind(fs);
+      const unlinkSpy = vi.spyOn(fs, 'unlink').mockImplementation(async (target) => {
+        if (path.resolve(String(target)) === path.resolve(lockPath)) {
+          throw Object.assign(new Error('unlink blocked'), { code: 'EPERM' });
+        }
+        return unlink(target);
+      });
+
+      try {
+        await expect(
+          publishIndexGenerationTransaction(storagePath, generation, async () => undefined),
+        ).rejects.toThrow('Failed to release owned lock');
+      } finally {
+        unlinkSpy.mockRestore();
+      }
+      await fs.unlink(lockPath);
+    } finally {
+      await temp.cleanup();
+    }
+  });
+
   it('binds loaded repository metadata and graph paths to one active generation', async () => {
     const temp = await createTempDir('ontoindex-load-generation-');
     const repoPath = temp.dbPath;
@@ -152,6 +355,53 @@ describe('index generations', () => {
     } finally {
       await temp.cleanup();
     }
+  });
+
+  it('retries when a generation activates while reading legacy metadata', async () => {
+    const storagePath = '/tmp/ontoindex-generation-activation';
+    const generation = {
+      generationId: 'generation-1',
+      generationPath: path.join(storagePath, 'generations', 'generation-1'),
+      lbugPath: path.join(storagePath, 'generations', 'generation-1', 'lbug'),
+      metaPath: path.join(storagePath, 'generations', 'generation-1', 'meta.json'),
+      snapshotPath: path.join(storagePath, 'generations', 'generation-1', 'snapshot.json'),
+    };
+    const generationMeta: RepoMeta = {
+      repoPath: '.',
+      lastCommit: 'abc123',
+      indexedAt: '2026-08-18T00:00:00.000Z',
+      generationId: generation.generationId,
+    };
+    const resolveActiveGeneration = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(generation)
+      .mockResolvedValueOnce(generation)
+      .mockResolvedValueOnce(generation);
+    const readMetaFile = vi
+      .fn()
+      .mockResolvedValueOnce({
+        repoPath: '.',
+        lastCommit: 'legacy',
+        indexedAt: '2026-08-17T00:00:00.000Z',
+      })
+      .mockResolvedValueOnce(generationMeta);
+
+    const result = await readActiveGenerationMeta(storagePath, {
+      resolveActiveGeneration,
+      readMetaFile,
+    });
+
+    expect(resolveActiveGeneration).toHaveBeenCalledTimes(4);
+    expect(readMetaFile).toHaveBeenNthCalledWith(1, path.join(storagePath, 'meta.json'));
+    expect(readMetaFile).toHaveBeenNthCalledWith(2, generation.metaPath);
+    expect(result).toEqual({
+      activeGeneration: generation,
+      meta: generationMeta,
+      authority: 'active-generation',
+    });
+    expect(result.activeGeneration?.generationId).toBe('generation-1');
+    expect(result.meta?.generationId).toBe(result.activeGeneration?.generationId);
   });
 });
 

--- a/ontoindex/test/unit/run-analyze-snapshot.test.ts
+++ b/ontoindex/test/unit/run-analyze-snapshot.test.ts
@@ -13,6 +13,24 @@ const { embeddingPipelineMocks } = vi.hoisted(() => ({
   },
 }));
 
+const { execFileTextMock } = vi.hoisted(() => ({
+  execFileTextMock: vi.fn().mockResolvedValue(''),
+}));
+
+const { repoManagerGenerationMockState } = vi.hoisted(() => ({
+  repoManagerGenerationMockState: {
+    canonicalGenerationId: null as string | null,
+  },
+}));
+
+const { managedAnalysisCoordinatorMocks } = vi.hoisted(() => ({
+  managedAnalysisCoordinatorMocks: {
+    claimManagedAnalysisAnalyzer: vi.fn().mockResolvedValue({}),
+    beginManagedAnalysisPublication: vi.fn().mockResolvedValue({}),
+    commitManagedAnalysisPublication: vi.fn().mockResolvedValue({}),
+  },
+}));
+
 vi.mock('../../src/core/ingestion/pipeline.js', () => ({
   runPipelineFromRepo: vi.fn(),
 }));
@@ -38,6 +56,15 @@ vi.mock('../../src/storage/repo-manager.js', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...(actual as any),
+    createIndexGeneration: vi.fn(async (...args: unknown[]) => {
+      const stagedGeneration = await (actual as any).createIndexGeneration(...args);
+      return repoManagerGenerationMockState.canonicalGenerationId
+        ? {
+            ...stagedGeneration,
+            generationId: repoManagerGenerationMockState.canonicalGenerationId,
+          }
+        : stagedGeneration;
+    }),
     loadMeta: vi.fn().mockResolvedValue(null),
     saveMeta: vi.fn().mockResolvedValue(undefined),
     registerRepo: vi.fn().mockResolvedValue('snapshot-test'),
@@ -65,6 +92,12 @@ vi.mock('../../src/core/search/bm25-index.js', () => ({
 
 vi.mock('../../src/core/embeddings/embedding-pipeline.js', () => embeddingPipelineMocks);
 
+vi.mock('../../src/core/process/exec-file.js', () => ({
+  execFileText: execFileTextMock,
+}));
+
+vi.mock('../../src/core/analysis/analysis-coordinator.js', () => managedAnalysisCoordinatorMocks);
+
 import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
 import { runFullAnalysis } from '../../src/core/run-analyze.js';
 import {
@@ -79,7 +112,21 @@ import {
   loadSidecarStoreState,
   MARKDOWN_DOCUMENT_ANALYZER_ID,
 } from '../../src/core/ingestion/enrichment/index.js';
-import { loadMeta, saveMeta } from '../../src/storage/repo-manager.js';
+import { addToGitignore, loadMeta, saveMeta } from '../../src/storage/repo-manager.js';
+import { getCurrentCommit } from '../../src/storage/git.js';
+import {
+  readAnalysisPublicationReceipt,
+  type ManagedAnalysisContext,
+} from '../../src/core/analysis/analysis-publication-receipt.js';
+import {
+  computeSourceManifest,
+  sourceManifestDigest,
+} from '../../src/core/indexing/source-manifest.js';
+import {
+  beginManagedAnalysisPublication,
+  claimManagedAnalysisAnalyzer,
+  commitManagedAnalysisPublication,
+} from '../../src/core/analysis/analysis-coordinator.js';
 
 const runPipelineMock = runPipelineFromRepo as unknown as ReturnType<typeof vi.fn>;
 const createFTSIndexMock = createFTSIndex as unknown as ReturnType<typeof vi.fn>;
@@ -94,14 +141,421 @@ const fetchExistingEmbeddingHashesMock = fetchExistingEmbeddingHashes as unknown
 >;
 const loadMetaMock = loadMeta as unknown as ReturnType<typeof vi.fn>;
 const saveMetaMock = saveMeta as unknown as ReturnType<typeof vi.fn>;
+const getCurrentCommitMock = getCurrentCommit as unknown as ReturnType<typeof vi.fn>;
+const addToGitignoreMock = addToGitignore as unknown as ReturnType<typeof vi.fn>;
+const claimManagedAnalysisAnalyzerMock = claimManagedAnalysisAnalyzer as unknown as ReturnType<
+  typeof vi.fn
+>;
+const beginManagedAnalysisPublicationMock =
+  beginManagedAnalysisPublication as unknown as ReturnType<typeof vi.fn>;
+const commitManagedAnalysisPublicationMock =
+  commitManagedAnalysisPublication as unknown as ReturnType<typeof vi.fn>;
+
+const MANAGED_TARGET_HEAD = 'a'.repeat(40);
+const MANAGED_OPTIONS_DIGEST = 'b'.repeat(64);
+const MANAGED_SOURCE_IDENTITY = `commit:${MANAGED_TARGET_HEAD}`;
+
+async function managedAnalysisContext(
+  repoDir: string,
+  jobId: string,
+  embeddings = false,
+): Promise<ManagedAnalysisContext> {
+  const manifest = await computeSourceManifest(repoDir, {
+    includePaths: [],
+    pipelineProfile: 'full',
+  });
+  return {
+    jobId,
+    targetHead: MANAGED_TARGET_HEAD,
+    optionsDigest: MANAGED_OPTIONS_DIGEST,
+    sourceIdentity: MANAGED_SOURCE_IDENTITY,
+    sourceManifestDigest: sourceManifestDigest(manifest),
+    requestedCapabilities: {
+      version: 1,
+      graph: true,
+      graphCapabilities: ['symbols'],
+      embeddings,
+      embeddingModelHash: embeddings ? 'managed-test-model' : null,
+    },
+  };
+}
 
 describe('runFullAnalysis snapshot persistence', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    repoManagerGenerationMockState.canonicalGenerationId = null;
     embeddingPipelineMocks.runEmbeddingPipeline.mockResolvedValue(undefined);
     embeddingPipelineMocks.batchInsertEmbeddings.mockResolvedValue(undefined);
     loadMetaMock.mockResolvedValue(null);
     getLbugStatsMock.mockResolvedValue({ nodes: 3, edges: 2 });
+    getCurrentCommitMock.mockReturnValue('abc123');
+    execFileTextMock.mockResolvedValue('');
+    claimManagedAnalysisAnalyzerMock.mockResolvedValue({});
+    beginManagedAnalysisPublicationMock.mockResolvedValue({});
+    commitManagedAnalysisPublicationMock.mockResolvedValue({});
+  });
+
+  it('requires force=true for managed analysis', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue(MANAGED_TARGET_HEAD);
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            managedAnalysis: await managedAnalysisContext(repoDir, 'managed-job-force'),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow('Managed analysis requires force=true.');
+      expect(runPipelineMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses managed publication when the current HEAD differs from the target', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue('c'.repeat(40));
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            force: true,
+            managedAnalysis: await managedAnalysisContext(repoDir, 'managed-job-head'),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow(
+        'Managed analysis target HEAD does not match the current repository HEAD before analysis.',
+      );
+      expect(runPipelineMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a dirty managed worktree before analysis starts', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue(MANAGED_TARGET_HEAD);
+      execFileTextMock.mockResolvedValueOnce(' M source.ts\n');
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            force: true,
+            managedAnalysis: await managedAnalysisContext(repoDir, 'managed-job-dirty-input'),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow('Managed analysis requires a clean Git worktree before analysis.');
+      expect(runPipelineMock).not.toHaveBeenCalled();
+      expect(addToGitignoreMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses managed publication when the worktree becomes dirty during analysis', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue(MANAGED_TARGET_HEAD);
+      execFileTextMock.mockResolvedValueOnce('').mockResolvedValueOnce('?? generated-source.ts\n');
+      runPipelineMock.mockResolvedValue({
+        graph: createKnowledgeGraph(),
+        repoPath: repoDir,
+        totalFileCount: 0,
+        communityResult: undefined,
+        processResult: undefined,
+        usedWorkerPool: false,
+      });
+      executeQueryMock.mockResolvedValue([]);
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            force: true,
+            managedAnalysis: await managedAnalysisContext(repoDir, 'managed-job-dirty-publication'),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow('Managed analysis requires a clean Git worktree before publication.');
+      expect(runPipelineMock).toHaveBeenCalledTimes(1);
+      expect(execFileTextMock).toHaveBeenCalledTimes(2);
+      await expect(
+        readAnalysisPublicationReceipt(
+          path.join(repoDir, '.ontoindex', 'current'),
+          'managed-job-dirty-publication',
+        ),
+      ).resolves.toBeNull();
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses managed publication when HEAD changes during analysis', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock
+        .mockReturnValueOnce(MANAGED_TARGET_HEAD)
+        .mockReturnValueOnce(MANAGED_TARGET_HEAD)
+        .mockReturnValueOnce(MANAGED_TARGET_HEAD)
+        .mockReturnValueOnce('c'.repeat(40));
+      runPipelineMock.mockResolvedValue({
+        graph: createKnowledgeGraph(),
+        repoPath: repoDir,
+        totalFileCount: 0,
+        communityResult: undefined,
+        processResult: undefined,
+        usedWorkerPool: false,
+      });
+      executeQueryMock.mockResolvedValue([]);
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            force: true,
+            managedAnalysis: await managedAnalysisContext(repoDir, 'managed-job-head-publication'),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow(
+        'Managed analysis target HEAD does not match the current repository HEAD before publication.',
+      );
+      expect(runPipelineMock).toHaveBeenCalledTimes(1);
+      expect(execFileTextMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('requires an enabled embedding path when managed analysis requests embeddings', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue(MANAGED_TARGET_HEAD);
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            force: true,
+            managedAnalysis: await managedAnalysisContext(
+              repoDir,
+              'managed-job-embeddings-disabled',
+              true,
+            ),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow(
+        'Managed analysis requested embeddings, but no embedding analysis option was enabled.',
+      );
+      expect(runPipelineMock).not.toHaveBeenCalled();
+      expect(execFileTextMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses managed publication when required embeddings are absent', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue(MANAGED_TARGET_HEAD);
+      runPipelineMock.mockResolvedValue({
+        graph: createKnowledgeGraph(),
+        repoPath: repoDir,
+        totalFileCount: 0,
+        communityResult: undefined,
+        processResult: undefined,
+        usedWorkerPool: false,
+      });
+      executeQueryMock.mockResolvedValue([]);
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            force: true,
+            embeddings: true,
+            managedAnalysis: await managedAnalysisContext(
+              repoDir,
+              'managed-job-embeddings-absent',
+              true,
+            ),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow(
+        'Managed analysis requested embeddings, but no embeddings were successfully published.',
+      );
+      expect(embeddingPipelineMocks.runEmbeddingPipeline).toHaveBeenCalledTimes(1);
+      expect(execFileTextMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes a managed receipt through the active generation', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue(MANAGED_TARGET_HEAD);
+      runPipelineMock.mockResolvedValue({
+        graph: createKnowledgeGraph(),
+        repoPath: repoDir,
+        totalFileCount: 0,
+        communityResult: undefined,
+        processResult: undefined,
+        usedWorkerPool: false,
+      });
+      executeQueryMock.mockResolvedValue([]);
+      repoManagerGenerationMockState.canonicalGenerationId = 'canonical-staged-generation';
+
+      await runFullAnalysis(
+        repoDir,
+        {
+          force: true,
+          managedAnalysis: await managedAnalysisContext(repoDir, 'managed-job-published'),
+        },
+        { onProgress: vi.fn() },
+      );
+
+      const receipt = await readAnalysisPublicationReceipt(
+        path.join(repoDir, '.ontoindex', 'current'),
+        'managed-job-published',
+      );
+      expect(receipt).toMatchObject({
+        version: 1,
+        jobId: 'managed-job-published',
+        repoPath: repoDir,
+        targetHead: MANAGED_TARGET_HEAD,
+        optionsDigest: MANAGED_OPTIONS_DIGEST,
+        sourceIdentity: MANAGED_SOURCE_IDENTITY,
+        requestedCapabilities: {
+          version: 1,
+          graph: true,
+          graphCapabilities: ['symbols'],
+          embeddings: false,
+          embeddingModelHash: null,
+        },
+        analyzerContractVersion: 'ontoindex-source-manifest-v1',
+      });
+      expect(receipt?.generationId).toBe('canonical-staged-generation');
+      await expect(fs.readlink(path.join(repoDir, '.ontoindex', 'current'))).resolves.toBe(
+        path.join('generations', 'canonical-staged-generation'),
+      );
+      expect(receipt?.sourceManifestDigest).toMatch(/^[0-9a-f]{64}$/);
+      expect(Number.isFinite(Date.parse(receipt?.publishedAt ?? ''))).toBe(true);
+      expect(claimManagedAnalysisAnalyzerMock).toHaveBeenCalledWith(
+        repoDir,
+        expect.objectContaining({ jobId: 'managed-job-published' }),
+      );
+      expect(beginManagedAnalysisPublicationMock).toHaveBeenCalledWith(
+        repoDir,
+        expect.objectContaining({ jobId: 'managed-job-published' }),
+      );
+      expect(commitManagedAnalysisPublicationMock).toHaveBeenCalledWith(
+        repoDir,
+        expect.objectContaining({ jobId: 'managed-job-published' }),
+        'canonical-staged-generation',
+        expect.stringMatching(/^[0-9a-f]{64}$/),
+      );
+      expect(execFileTextMock).toHaveBeenCalledTimes(2);
+      expect(execFileTextMock).toHaveBeenCalledWith(
+        'git',
+        ['status', '--porcelain=v1', '--untracked-files=all'],
+        expect.objectContaining({ cwd: repoDir }),
+      );
+      expect(addToGitignoreMock).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not publish or activate when managed publication ownership is fenced', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue(MANAGED_TARGET_HEAD);
+      runPipelineMock.mockResolvedValue({
+        graph: createKnowledgeGraph(),
+        repoPath: repoDir,
+        totalFileCount: 0,
+        communityResult: undefined,
+        processResult: undefined,
+        usedWorkerPool: false,
+      });
+      executeQueryMock.mockResolvedValue([]);
+      beginManagedAnalysisPublicationMock.mockRejectedValueOnce(
+        new Error('Managed analysis attempt was fenced.'),
+      );
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            force: true,
+            managedAnalysis: await managedAnalysisContext(repoDir, 'managed-job-fenced'),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow('Managed analysis attempt was fenced.');
+      expect(commitManagedAnalysisPublicationMock).not.toHaveBeenCalled();
+
+      await expect(
+        readAnalysisPublicationReceipt(
+          path.join(repoDir, '.ontoindex', 'current'),
+          'managed-job-fenced',
+        ),
+      ).resolves.toBeNull();
+      await expect(fs.lstat(path.join(repoDir, '.ontoindex', 'current'))).rejects.toThrow();
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls back activation when managed publication commit is fenced', async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-run-analyze-managed-'));
+    try {
+      getCurrentCommitMock.mockReturnValue(MANAGED_TARGET_HEAD);
+      runPipelineMock.mockResolvedValue({
+        graph: createKnowledgeGraph(),
+        repoPath: repoDir,
+        totalFileCount: 0,
+        communityResult: undefined,
+        processResult: undefined,
+        usedWorkerPool: false,
+      });
+      executeQueryMock.mockResolvedValue([]);
+      repoManagerGenerationMockState.canonicalGenerationId = 'failed-publication-generation';
+      commitManagedAnalysisPublicationMock.mockRejectedValueOnce(
+        new Error('Managed analysis publication commit was fenced.'),
+      );
+
+      await expect(
+        runFullAnalysis(
+          repoDir,
+          {
+            force: true,
+            managedAnalysis: await managedAnalysisContext(repoDir, 'managed-job-commit-fenced'),
+          },
+          { onProgress: vi.fn() },
+        ),
+      ).rejects.toThrow('Managed analysis publication commit was fenced.');
+
+      await expect(fs.lstat(path.join(repoDir, '.ontoindex', 'current'))).rejects.toThrow();
+      await expect(fs.lstat(path.join(repoDir, '.ontoindex', 'lbug'))).rejects.toThrow();
+      await expect(
+        fs.lstat(path.join(repoDir, '.ontoindex', 'generations', 'failed-publication-generation')),
+      ).resolves.toBeDefined();
+    } finally {
+      await fs.rm(repoDir, { recursive: true, force: true });
+    }
   });
 
   it('writes snapshot.json for graph_diff after a successful analyze', async () => {

--- a/ontoindex/test/unit/runtime-health.test.ts
+++ b/ontoindex/test/unit/runtime-health.test.ts
@@ -327,4 +327,42 @@ describe('deriveRuntimeHealth', () => {
       await fs.rm(repoPath, { recursive: true, force: true });
     }
   });
+
+  it('does not load on-disk metadata when meta is explicitly null', async () => {
+    const storagePath = await fs.mkdtemp(path.join(os.tmpdir(), 'runtime-health-explicit-null-'));
+    try {
+      await fs.writeFile(
+        path.join(storagePath, 'meta.json'),
+        JSON.stringify({
+          repoPath: '.',
+          lastCommit: 'disk-only-commit',
+          indexedAt: '2026-08-18T00:00:00.000Z',
+          degradedFileAggregates: {
+            sampledDegradedCount: 1,
+            groups: [
+              {
+                cause: 'disk metadata sentinel',
+                phase: 'test',
+                language: 'typescript',
+                count: 1,
+              },
+            ],
+            omittedGroupCount: 0,
+          },
+        } satisfies RepoMeta),
+      );
+
+      const health = await readRuntimeHealth(process.cwd(), {
+        repoLabel: 'explicit-null-fixture',
+        storagePath,
+        meta: null,
+      });
+
+      expect(health.indexedCommit).toBeNull();
+      expect(health.degradedFileAggregates).toBeUndefined();
+      expect(health.freshnessState).toBe('untrusted');
+    } finally {
+      await fs.rm(storagePath, { recursive: true, force: true });
+    }
+  });
 });

--- a/ontoindex/test/unit/super/analyze-job.test.ts
+++ b/ontoindex/test/unit/super/analyze-job.test.ts
@@ -1,0 +1,538 @@
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/core/analysis/analysis-coordinator.js', () => ({
+  cancelAnalysisJob: vi.fn(),
+  getAnalysisJob: vi.fn(),
+}));
+vi.mock('../../../src/core/analysis/analysis-publication-receipt.js', () => ({
+  readAnalysisPublicationReceipt: vi.fn(),
+}));
+vi.mock('../../../src/storage/repo-manager.js', () => ({
+  resolveActiveIndexGeneration: vi.fn(),
+}));
+vi.mock('../../../src/mcp/shared/target-context.js', () => ({ resolveTargetContext: vi.fn() }));
+vi.mock('../../../src/mcp/super/ensure-fresh.js', () => ({ gnEnsureFresh: vi.fn() }));
+
+import {
+  cancelAnalysisJob,
+  getAnalysisJob,
+  type AnalysisJobRecord,
+} from '../../../src/core/analysis/analysis-coordinator.js';
+import { readAnalysisPublicationReceipt } from '../../../src/core/analysis/analysis-publication-receipt.js';
+import { SOURCE_MANIFEST_CONTRACT } from '../../../src/core/indexing/source-manifest.js';
+import { resolveActiveIndexGeneration } from '../../../src/storage/repo-manager.js';
+import { resolveTargetContext } from '../../../src/mcp/shared/target-context.js';
+import { gnAnalyzeJob } from '../../../src/mcp/super/analyze-job.js';
+import { gnEnsureFresh } from '../../../src/mcp/super/ensure-fresh.js';
+
+const cancelJob = vi.mocked(cancelAnalysisJob);
+const getJob = vi.mocked(getAnalysisJob);
+const readReceipt = vi.mocked(readAnalysisPublicationReceipt);
+const activeGeneration = vi.mocked(resolveActiveIndexGeneration);
+const targetContext = vi.mocked(resolveTargetContext);
+const ensureFresh = vi.mocked(gnEnsureFresh);
+
+const repoPath = path.resolve('/workspace/repo');
+const targetHead = 'a'.repeat(40);
+const otherHead = 'b'.repeat(40);
+const optionsDigest = 'c'.repeat(64);
+const manifestDigest = 'd'.repeat(64);
+const generationId = 'generation-1';
+const jobId = 'job-1';
+
+const graphCapabilities = ['symbols'] as const;
+
+function requestedCapabilities(
+  overrides: Partial<AnalysisJobRecord['requestedCapabilities']> = {},
+): AnalysisJobRecord['requestedCapabilities'] {
+  return {
+    version: 1,
+    graph: true,
+    graphCapabilities: [...graphCapabilities],
+    embeddings: false,
+    embeddingModelHash: null,
+    ...overrides,
+  };
+}
+
+function makeJob(overrides: Partial<AnalysisJobRecord> = {}): AnalysisJobRecord {
+  return {
+    version: 1,
+    id: jobId,
+    status: 'complete',
+    repoPath,
+    targetHead,
+    sourceIdentity: `commit:${targetHead}`,
+    requestedCapabilities: requestedCapabilities(),
+    optionsDigest,
+    command: process.execPath,
+    args: ['analyze'],
+    logPath: path.join(repoPath, '.ontoindex', 'analysis-jobs', `${jobId}.log`),
+    createdAt: '2026-08-18T00:00:00.000Z',
+    completedAt: '2026-08-18T00:01:00.000Z',
+    exitCode: 0,
+    generationId,
+    sourceManifestDigest: manifestDigest,
+    ...overrides,
+  };
+}
+
+function makeReceipt(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 1,
+    jobId,
+    repoPath,
+    targetHead,
+    sourceIdentity: `commit:${targetHead}`,
+    optionsDigest,
+    sourceManifestDigest: manifestDigest,
+    generationId,
+    requestedCapabilities: requestedCapabilities(),
+    analyzerContractVersion: SOURCE_MANIFEST_CONTRACT,
+    publishedAt: '2026-08-18T00:00:59.000Z',
+    ...overrides,
+  };
+}
+
+function makeFreshness(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 1,
+    preCheck: { indexedCommit: targetHead, currentCommit: targetHead, isStale: false },
+    embeddingsStatus: { count: 0, required: false, status: 'missing' },
+    repoLabel: 'repo',
+    repoPath,
+    indexedCommit: targetHead,
+    headCommit: targetHead,
+    isStale: false,
+    dirtyFileCount: 0,
+    actionsTaken: [],
+    analysisSubmission: { status: 'not-requested' },
+    warnings: [],
+    recommendations: [],
+    ...overrides,
+  };
+}
+
+function makeTargetContext(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 1,
+    status: 'ok',
+    repoPath,
+    targetRef: 'HEAD',
+    targetHead,
+    currentHead: targetHead,
+    indexedHead: targetHead,
+    graphAuthority: {
+      state: 'authoritative',
+      reason: 'verified',
+      generationId,
+      manifestDigest,
+      coverage: 'complete',
+    },
+    dirtyWorktree: false,
+    changedSinceIndex: false,
+    snapshotMode: 'committed-head',
+    qualityMode: 'fast',
+    embeddings: { status: 'unknown' },
+    lsp: { status: 'unknown' },
+    sidecar: { status: 'unknown' },
+    policy: { status: 'unknown' },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('gnAnalyzeJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ensureFresh.mockResolvedValue(makeFreshness() as any);
+    getJob.mockResolvedValue(makeJob());
+    activeGeneration.mockResolvedValue({
+      generationId,
+      generationPath: path.join(repoPath, '.ontoindex', 'generations', generationId),
+    } as any);
+    readReceipt.mockResolvedValue(makeReceipt() as any);
+    targetContext.mockResolvedValue(makeTargetContext() as any);
+  });
+
+  it('preserves cancel compatibility without recovery checks', async () => {
+    cancelJob.mockResolvedValue({ job: makeJob({ status: 'running' }), cancelled: true });
+    const result = await gnAnalyzeJob('repo', { jobId, action: 'cancel' });
+    expect(result).toMatchObject({ cancelled: true, repoLabel: 'repo', repoPath });
+    expect(readReceipt).not.toHaveBeenCalled();
+  });
+
+  it.each(['queued', 'running'] as const)('reports %s as refresh running', async (status) => {
+    getJob.mockResolvedValue(makeJob({ status }));
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'REFRESH_RUNNING',
+      reasonCode: 'ANALYSIS_IN_PROGRESS',
+    });
+    expect(activeGeneration).not.toHaveBeenCalled();
+  });
+
+  it.each(['queued', 'running'] as const)(
+    'fails closed for %s without exact commit source identity',
+    async (status) => {
+      getJob.mockResolvedValue(makeJob({ status, sourceIdentity: undefined }));
+      const result: any = await gnAnalyzeJob('repo', { jobId });
+      expect(result.recovery).toMatchObject({
+        disposition: 'FRESHNESS_UNCONFIRMED',
+        reasonCode: 'JOB_SOURCE_IDENTITY_MISMATCH',
+      });
+      expect(activeGeneration).not.toHaveBeenCalled();
+    },
+  );
+
+  it('reports cancelled as failed', async () => {
+    getJob.mockResolvedValue(makeJob({ status: 'cancelled' }));
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({ disposition: 'FAILED', reasonCode: 'CANCELLED' });
+  });
+
+  it.each([
+    ['complete', 'FRESHNESS_UNCONFIRMED', 'PUBLICATION_RECEIPT_UNAVAILABLE'],
+    ['failed', 'FAILED', 'ANALYSIS_FAILED'],
+  ] as const)('fails closed without a receipt for %s', async (status, disposition, reasonCode) => {
+    getJob.mockResolvedValue(makeJob({ status, exitCode: status === 'failed' ? 7 : 0 }));
+    readReceipt.mockResolvedValue(null);
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition,
+      reasonCode,
+    });
+    expect(readReceipt).toHaveBeenCalledTimes(status === 'complete' ? 1 : 0);
+  });
+
+  it('fails closed for a pre-upgrade terminal job without capability identity', async () => {
+    getJob.mockResolvedValue({ ...makeJob(), requestedCapabilities: undefined } as any);
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'JOB_CAPABILITIES_UNAVAILABLE',
+    });
+    expect(activeGeneration).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, 'not-a-digest'])(
+    'fails closed without a valid job manifest identity',
+    async (digest) => {
+      getJob.mockResolvedValue(makeJob({ sourceManifestDigest: digest as any }));
+      const result: any = await gnAnalyzeJob('repo', { jobId });
+      expect(result.recovery).toMatchObject({
+        disposition: 'FRESHNESS_UNCONFIRMED',
+        reasonCode: 'JOB_MANIFEST_IDENTITY_UNAVAILABLE',
+      });
+      expect(activeGeneration).not.toHaveBeenCalled();
+    },
+  );
+
+  it('fails closed for embedding capabilities without a model identity', async () => {
+    getJob.mockResolvedValue(
+      makeJob({
+        requestedCapabilities: requestedCapabilities({
+          embeddings: true,
+          embeddingModelHash: null,
+        }),
+      }),
+    );
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'JOB_CAPABILITIES_UNAVAILABLE',
+    });
+  });
+
+  it.each([
+    ['complete', 'FRESHNESS_UNCONFIRMED'],
+    ['failed', 'FAILED'],
+  ] as const)(
+    'fails closed for %s when job source identity is unavailable',
+    async (status, disposition) => {
+      getJob.mockResolvedValue(
+        makeJob({ status, sourceIdentity: undefined, exitCode: status === 'failed' ? 7 : 0 }),
+      );
+      const result: any = await gnAnalyzeJob('repo', { jobId });
+      expect(result.recovery).toMatchObject({
+        disposition,
+        reasonCode: 'JOB_SOURCE_IDENTITY_MISMATCH',
+      });
+      expect(activeGeneration).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects receipt identity and capability mismatches', async () => {
+    readReceipt.mockResolvedValue(
+      makeReceipt({
+        requestedCapabilities: requestedCapabilities({
+          graphCapabilities: ['impact', 'symbols'],
+        }),
+      }) as any,
+    );
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'RECEIPT_CAPABILITIES_MISMATCH',
+    });
+  });
+
+  it('rejects a receipt whose source identity does not match the job', async () => {
+    readReceipt.mockResolvedValue(makeReceipt({ sourceIdentity: `commit:${otherHead}` }) as any);
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'RECEIPT_SOURCE_IDENTITY_MISMATCH',
+    });
+  });
+
+  it('rejects a receipt whose manifest identity does not match the job', async () => {
+    readReceipt.mockResolvedValue(makeReceipt({ sourceManifestDigest: 'e'.repeat(64) }) as any);
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'RECEIPT_MANIFEST_MISMATCH',
+    });
+  });
+
+  it('reports refreshed only after receipt, target, authority, and generation checks pass', async () => {
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'REFRESHED',
+      reasonCode: 'PUBLICATION_VERIFIED',
+      receipt: { generationId },
+      postCheck: { indexedCommit: targetHead, headCommit: targetHead },
+    });
+    expect(ensureFresh).toHaveBeenNthCalledWith(2, repoPath, {
+      repo: repoPath,
+      withEmbeddings: false,
+      requiredGraphCapabilities: ['symbols'],
+    });
+    expect(ensureFresh).toHaveBeenNthCalledWith(3, repoPath, {
+      repo: repoPath,
+      withEmbeddings: false,
+      requiredGraphCapabilities: ['symbols'],
+    });
+    expect(ensureFresh).toHaveBeenNthCalledWith(4, repoPath, {
+      repo: repoPath,
+      withEmbeddings: false,
+      requiredGraphCapabilities: ['symbols'],
+    });
+    expect(targetContext).toHaveBeenCalledTimes(3);
+    expect(activeGeneration).toHaveBeenCalledTimes(3);
+    expect(targetContext).toHaveBeenCalledWith({
+      repo: repoPath,
+      verifyGraphAuthority: true,
+      requiredGraphCapabilities: ['symbols'],
+    });
+  });
+
+  it('keeps a failed execution failed even if receipt and postconditions look successful', async () => {
+    getJob.mockResolvedValue(makeJob({ status: 'failed', exitCode: 9 }));
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.job).toMatchObject({ status: 'failed', exitCode: 9 });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FAILED',
+      reasonCode: 'ANALYSIS_FAILED',
+    });
+    expect(result.recovery.message).toContain('exit code 9');
+    expect(activeGeneration).not.toHaveBeenCalled();
+    expect(readReceipt).not.toHaveBeenCalled();
+    expect(targetContext).not.toHaveBeenCalled();
+    expect(ensureFresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not bless a job after HEAD advances beyond its target', async () => {
+    ensureFresh.mockResolvedValueOnce(makeFreshness() as any).mockResolvedValueOnce(
+      makeFreshness({
+        preCheck: { indexedCommit: targetHead, currentCommit: otherHead, isStale: true },
+        headCommit: otherHead,
+        isStale: true,
+      }) as any,
+    );
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'POSTCHECK_TARGET_MISMATCH',
+    });
+  });
+
+  it('fails closed when the checkout changes after the first valid post-check', async () => {
+    ensureFresh
+      .mockResolvedValueOnce(makeFreshness() as any)
+      .mockResolvedValueOnce(makeFreshness() as any)
+      .mockResolvedValueOnce(
+        makeFreshness({
+          preCheck: { indexedCommit: targetHead, currentCommit: otherHead, isStale: true },
+          headCommit: otherHead,
+          isStale: true,
+        }) as any,
+      );
+
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'POSTCHECK_TARGET_MISMATCH',
+    });
+  });
+
+  it.each([
+    [
+      'a dirty freshness post-check',
+      {
+        freshness: { dirtyFileCount: 1 },
+        context: {},
+        reasonCode: 'POSTCHECK_WORKTREE_UNCONFIRMED',
+      },
+    ],
+    [
+      'an unconfirmed target worktree',
+      {
+        freshness: {},
+        context: { dirtyWorktree: null },
+        reasonCode: 'TARGET_CONTEXT_WORKTREE_UNCONFIRMED',
+      },
+    ],
+    [
+      'a non-committed snapshot',
+      {
+        freshness: {},
+        context: { snapshotMode: 'dirty-worktree-overlay' },
+        reasonCode: 'TARGET_CONTEXT_SNAPSHOT_MISMATCH',
+      },
+    ],
+    [
+      'changes since the published index',
+      {
+        freshness: {},
+        context: { changedSinceIndex: true },
+        reasonCode: 'TARGET_CONTEXT_INDEX_DRIFT',
+      },
+    ],
+  ] as const)('fails closed for %s', async (_label, proof) => {
+    ensureFresh
+      .mockResolvedValueOnce(makeFreshness() as any)
+      .mockResolvedValueOnce(makeFreshness(proof.freshness) as any);
+    targetContext.mockResolvedValue(makeTargetContext(proof.context) as any);
+
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: proof.reasonCode,
+    });
+  });
+
+  it('fails closed when the authoritative post-check cannot be completed', async () => {
+    ensureFresh
+      .mockResolvedValueOnce(makeFreshness() as any)
+      .mockRejectedValueOnce(new Error('no'));
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'POSTCHECK_UNAVAILABLE',
+      receipt: { jobId },
+    });
+  });
+
+  it('requires embeddings when the job requested them', async () => {
+    const embeddingCapabilities = requestedCapabilities({
+      graphCapabilities: ['impact', 'processes', 'symbols'],
+      embeddings: true,
+      embeddingModelHash: 'sha256:model-a',
+    });
+    getJob.mockResolvedValue(makeJob({ requestedCapabilities: embeddingCapabilities }));
+    readReceipt.mockResolvedValue(
+      makeReceipt({ requestedCapabilities: embeddingCapabilities }) as any,
+    );
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'EMBEDDINGS_UNCONFIRMED',
+    });
+    expect(ensureFresh).toHaveBeenNthCalledWith(2, repoPath, {
+      repo: repoPath,
+      withEmbeddings: true,
+      requiredGraphCapabilities: ['impact', 'processes', 'symbols'],
+    });
+  });
+
+  it('reports refreshed when the requested embedding model is proven end to end', async () => {
+    const embeddingCapabilities = requestedCapabilities({
+      graphCapabilities: ['impact', 'processes', 'symbols'],
+      embeddings: true,
+      embeddingModelHash: 'sha256:model-a',
+    });
+    getJob.mockResolvedValue(makeJob({ requestedCapabilities: embeddingCapabilities }));
+    readReceipt.mockResolvedValue(
+      makeReceipt({ requestedCapabilities: embeddingCapabilities }) as any,
+    );
+    ensureFresh.mockResolvedValue(
+      makeFreshness({
+        embeddingsStatus: {
+          count: 12,
+          required: false,
+          status: 'ok',
+          expectedModelHash: 'sha256:model-a',
+          actualModelHash: 'sha256:model-a',
+        },
+      }) as any,
+    );
+    targetContext.mockResolvedValue(
+      makeTargetContext({
+        embeddings: { status: 'available', count: 12, modelHash: 'sha256:model-a' },
+      }) as any,
+    );
+
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+
+    expect(result.recovery).toMatchObject({
+      disposition: 'REFRESHED',
+      reasonCode: 'PUBLICATION_VERIFIED',
+    });
+  });
+
+  it('fails closed if active generation changes during verification', async () => {
+    activeGeneration
+      .mockResolvedValueOnce({
+        generationId,
+        generationPath: path.join(repoPath, '.ontoindex', 'generations', generationId),
+      } as any)
+      .mockResolvedValueOnce({
+        generationId: 'generation-2',
+        generationPath: path.join(repoPath, '.ontoindex', 'generations', 'generation-2'),
+      } as any);
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'ACTIVE_GENERATION_CHANGED',
+    });
+  });
+
+  it('fails closed if active generation changes after the final post-check', async () => {
+    activeGeneration
+      .mockResolvedValueOnce({
+        generationId,
+        generationPath: path.join(repoPath, '.ontoindex', 'generations', generationId),
+      } as any)
+      .mockResolvedValueOnce({
+        generationId,
+        generationPath: path.join(repoPath, '.ontoindex', 'generations', generationId),
+      } as any)
+      .mockResolvedValueOnce({
+        generationId: 'generation-2',
+        generationPath: path.join(repoPath, '.ontoindex', 'generations', 'generation-2'),
+      } as any);
+
+    const result: any = await gnAnalyzeJob('repo', { jobId });
+
+    expect(result.recovery).toMatchObject({
+      disposition: 'FRESHNESS_UNCONFIRMED',
+      reasonCode: 'ACTIVE_GENERATION_CHANGED',
+    });
+    expect(ensureFresh).toHaveBeenCalledTimes(3);
+    expect(targetContext).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ontoindex/test/unit/super/analyze-job.test.ts
+++ b/ontoindex/test/unit/super/analyze-job.test.ts
@@ -7,6 +7,8 @@ vi.mock('../../../src/core/analysis/analysis-coordinator.js', () => ({
 }));
 vi.mock('../../../src/core/analysis/analysis-publication-receipt.js', () => ({
   readAnalysisPublicationReceipt: vi.fn(),
+  isValidSourceIdentity: (value: unknown, targetHead: string, digest: string) =>
+    value === `commit:${targetHead}` || value === `worktree:${digest}`,
 }));
 vi.mock('../../../src/storage/repo-manager.js', () => ({
   resolveActiveIndexGeneration: vi.fn(),

--- a/ontoindex/test/unit/super/diagnose.test.ts
+++ b/ontoindex/test/unit/super/diagnose.test.ts
@@ -127,9 +127,10 @@ function makeFreshReport(
     embeddingsStatus?: 'ok' | 'missing' | 'metadata-unavailable' | 'drifted';
     repairCommand?: string;
     reason?: string;
+    dirtyFileCount?: number | null;
   } = {},
 ) {
-  const { isStale = false, embeddingsCount = 0 } = options;
+  const { isStale = false, embeddingsCount = 0, dirtyFileCount = 0 } = options;
   const embeddingsStatus = options.embeddingsStatus ?? (embeddingsCount > 0 ? 'ok' : 'missing');
   const repairCommand =
     options.repairCommand ??
@@ -142,6 +143,7 @@ function makeFreshReport(
   return {
     version: 1 as const,
     preCheck: { indexedCommit, currentCommit: CURRENT_COMMIT, isStale },
+    dirtyFileCount,
     embeddingsStatus: {
       count: embeddingsCount,
       required: false,
@@ -305,7 +307,7 @@ describe('gnDiagnose', () => {
 
   // ---- Test 2: Stale index → WARN recommendation generated ------------------
   it('emits a WARN recommendation when the index is stale', async () => {
-    mockGnEnsureFresh.mockResolvedValue(makeFreshReport({ isStale: true }));
+    mockGnEnsureFresh.mockResolvedValue(makeFreshReport({ isStale: true, dirtyFileCount: 0 }));
 
     const report = await gnDiagnose(REPO_ID, {
       checkLsp: false,
@@ -321,6 +323,37 @@ describe('gnDiagnose', () => {
     expect(warnRec).toBeDefined();
     expect(warnRec!.detail).toMatch(/stale/i);
     expect(warnRec!.fix).toBe('gn_ensure_fresh({autoAnalyze: true})');
+  });
+
+  it('does not recommend autoAnalyze while the worktree is dirty', async () => {
+    mockGnEnsureFresh.mockResolvedValue(makeFreshReport({ isStale: true, dirtyFileCount: 266 }));
+
+    const report = await gnDiagnose(REPO_ID, {
+      checkLsp: false,
+      checkEmbeddings: false,
+      checkIndexFreshness: true,
+    });
+
+    const warnRec = report.recommendations.find((r) => r.severity === 'WARN');
+    expect(warnRec).toBeDefined();
+    // The refused repair must not be advertised as the fix.
+    expect(warnRec!.fix).not.toBe('gn_ensure_fresh({autoAnalyze: true})');
+    expect(warnRec!.fix).toContain('266 changed files');
+    expect(warnRec!.fix).toMatch(/commit or stash/i);
+  });
+
+  it('flags unknown worktree status instead of recommending autoAnalyze', async () => {
+    mockGnEnsureFresh.mockResolvedValue(makeFreshReport({ isStale: true, dirtyFileCount: null }));
+
+    const report = await gnDiagnose(REPO_ID, {
+      checkLsp: false,
+      checkEmbeddings: false,
+      checkIndexFreshness: true,
+    });
+
+    const warnRec = report.recommendations.find((r) => r.severity === 'WARN');
+    expect(warnRec!.fix).not.toBe('gn_ensure_fresh({autoAnalyze: true})');
+    expect(warnRec!.fix).toMatch(/worktree status is unavailable/i);
   });
 
   // ---- Test 3: LSP probe handles ENOENT gracefully --------------------------

--- a/ontoindex/test/unit/super/ensure-fresh.test.ts
+++ b/ontoindex/test/unit/super/ensure-fresh.test.ts
@@ -24,6 +24,8 @@ vi.mock('fs', () => ({
 
 vi.mock('../../../src/storage/repo-manager.js', () => ({
   loadMeta: vi.fn(),
+  readActiveGenerationMeta: vi.fn(),
+  resolveActiveIndexGeneration: vi.fn(),
 }));
 
 vi.mock('os', () => ({
@@ -36,6 +38,11 @@ vi.mock('../../../src/core/runtime/runtime-health.js', () => ({
 
 vi.mock('../../../src/core/analysis/analysis-coordinator.js', () => ({
   submitAnalysisJob: vi.fn(),
+}));
+
+vi.mock('../../../src/core/indexing/source-manifest.js', () => ({
+  computeSourceManifest: vi.fn(),
+  sourceManifestDigest: vi.fn(),
 }));
 
 vi.mock('../../../src/mcp/shared/target-context.js', () => ({
@@ -51,8 +58,16 @@ import { execFile, spawn } from 'child_process';
 import { readFileSync } from 'fs';
 import { gnEnsureFresh } from '../../../src/mcp/super/ensure-fresh.js';
 import { readRuntimeHealth } from '../../../src/core/runtime/runtime-health.js';
-import { loadMeta } from '../../../src/storage/repo-manager.js';
+import {
+  loadMeta,
+  readActiveGenerationMeta,
+  resolveActiveIndexGeneration,
+} from '../../../src/storage/repo-manager.js';
 import { submitAnalysisJob } from '../../../src/core/analysis/analysis-coordinator.js';
+import {
+  computeSourceManifest,
+  sourceManifestDigest,
+} from '../../../src/core/indexing/source-manifest.js';
 import { resolveTargetContext } from '../../../src/mcp/shared/target-context.js';
 
 const mockExecFile = vi.mocked(execFile);
@@ -60,7 +75,11 @@ const mockSpawn = vi.mocked(spawn);
 const mockReadFileSync = vi.mocked(readFileSync);
 const mockReadRuntimeHealth = vi.mocked(readRuntimeHealth);
 const mockLoadMeta = vi.mocked(loadMeta);
+const mockReadActiveGenerationMeta = vi.mocked(readActiveGenerationMeta);
+const mockResolveActiveIndexGeneration = vi.mocked(resolveActiveIndexGeneration);
 const mockSubmitAnalysisJob = vi.mocked(submitAnalysisJob);
+const mockComputeSourceManifest = vi.mocked(computeSourceManifest);
+const mockSourceManifestDigest = vi.mocked(sourceManifestDigest);
 const mockResolveTargetContext = vi.mocked(resolveTargetContext);
 
 let savedEnv: Record<string, string | undefined> = {};
@@ -74,6 +93,7 @@ const REPO_PATH = path.resolve('/home/testuser/_wrk/test-repo');
 const CURRENT_COMMIT = 'abc123def456abc123def456abc123def456abc1';
 const INDEXED_COMMIT = 'abc123def456abc123def456abc123def456abc1'; // same = fresh
 const EMBEDDING_MODEL_HASH = 'hash-a';
+const SOURCE_MANIFEST_DIGEST = 'd'.repeat(64);
 
 const STALE_INDEXED_COMMIT = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
 
@@ -157,6 +177,7 @@ function makeMeta(
     repoPath: REPO_PATH,
     lastCommit: options.lastCommit ?? INDEXED_COMMIT,
     indexedAt: '2026-06-17T00:00:00.000Z',
+    generationId: 'generation-1',
     model_hash: options.modelHash ?? EMBEDDING_MODEL_HASH,
     stats: {
       embeddings: options.embeddings ?? 12,
@@ -221,6 +242,33 @@ describe('gnEnsureFresh', () => {
     setupSpawnExit();
     mockReadRuntimeHealth.mockResolvedValue(makeRuntimeHealth());
     mockLoadMeta.mockResolvedValue(makeMeta() as any);
+    mockResolveActiveIndexGeneration.mockResolvedValue({
+      generationId: 'generation-1',
+      generationPath: `${REPO_PATH}/.ontoindex/generations/generation-1`,
+    } as any);
+    mockReadActiveGenerationMeta.mockImplementation(async (storagePath) => {
+      const activeGeneration = await mockResolveActiveIndexGeneration(storagePath);
+      const meta = await mockLoadMeta(storagePath);
+
+      if (activeGeneration && meta?.generationId === activeGeneration.generationId) {
+        return { activeGeneration, meta, authority: 'active-generation' };
+      }
+      if (!activeGeneration && meta && meta.generationId === undefined) {
+        return { activeGeneration: null, meta, authority: 'legacy-root' };
+      }
+      return {
+        activeGeneration,
+        meta: null,
+        authority: 'untrusted',
+        reason: activeGeneration
+          ? meta
+            ? 'active-generation-metadata-mismatch'
+            : 'active-generation-metadata-unavailable'
+          : meta?.generationId
+            ? 'generation-tagged-root-metadata-without-active-generation'
+            : 'legacy-root-metadata-unavailable',
+      };
+    });
     mockSubmitAnalysisJob.mockResolvedValue({
       reused: false,
       job: {
@@ -236,6 +284,19 @@ describe('gnEnsureFresh', () => {
         createdAt: '2026-08-05T00:00:00.000Z',
       },
     });
+    mockComputeSourceManifest.mockResolvedValue({
+      version: 1,
+      head: CURRENT_COMMIT,
+      sourceDigest: 'source-digest',
+      sourceEntryCount: 1,
+      includePaths: [],
+      scopeDigest: 'scope-digest',
+      ignorePolicyDigest: 'ignore-digest',
+      pipelineProfile: 'full',
+      analyzerContractVersion: 'ontoindex-source-manifest-v1',
+      coverage: 'complete',
+    });
+    mockSourceManifestDigest.mockReturnValue(SOURCE_MANIFEST_DIGEST);
     mockResolveTargetContext.mockResolvedValue({
       version: 1,
       status: 'ok',
@@ -391,7 +452,8 @@ describe('gnEnsureFresh', () => {
   // ---- Test 2: Stale without autoAnalyze → recommendations, no actions ----
   it('populates recommendations but takes no actions when stale and autoAnalyze is false', async () => {
     setupExecFile({ currentCommit: CURRENT_COMMIT });
-    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
 
     const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: false });
 
@@ -408,13 +470,31 @@ describe('gnEnsureFresh', () => {
   it('submits ontoindex analyze when stale and autoAnalyze: true', async () => {
     setupExecFile({ currentCommit: CURRENT_COMMIT });
     // First readFileSync call: pre-check registry; second: post-check registry
-    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
 
     const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
 
+    expect(mockSubmitAnalysisJob).toHaveBeenCalledTimes(1);
     expect(mockSubmitAnalysisJob).toHaveBeenCalledWith(
-      expect.objectContaining({ repoPath: REPO_PATH, targetHead: CURRENT_COMMIT }),
+      expect.objectContaining({
+        repoPath: REPO_PATH,
+        targetHead: CURRENT_COMMIT,
+        sourceIdentity: `commit:${CURRENT_COMMIT}`,
+        requestedCapabilities: {
+          version: 1,
+          graph: true,
+          graphCapabilities: ['symbols'],
+          embeddings: false,
+          embeddingModelHash: null,
+        },
+        sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+      }),
     );
+    expect(mockComputeSourceManifest).toHaveBeenCalledWith(REPO_PATH, {
+      includePaths: [],
+      pipelineProfile: 'full',
+    });
     expect(mockSubmitAnalysisJob.mock.calls[0][0].args).toContain('analyze');
     expect(mockSubmitAnalysisJob.mock.calls[0][0].args).not.toContain('--embeddings');
 
@@ -475,11 +555,173 @@ describe('gnEnsureFresh', () => {
   it('adds --embeddings to analyze args when withEmbeddings: true', async () => {
     setupExecFile({ currentCommit: CURRENT_COMMIT });
     mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
 
     await gnEnsureFresh(REPO_ID, { autoAnalyze: true, withEmbeddings: true });
 
     expect(mockSubmitAnalysisJob).toHaveBeenCalledTimes(1);
     expect(mockSubmitAnalysisJob.mock.calls[0][0].args).toContain('--embeddings');
+    expect(mockSubmitAnalysisJob.mock.calls[0][0].requestedCapabilities).toEqual({
+      version: 1,
+      graph: true,
+      graphCapabilities: ['symbols'],
+      embeddings: true,
+      embeddingModelHash: EMBEDDING_MODEL_HASH,
+    });
+  });
+
+  it('normalizes requested graph capabilities before submission', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+
+    await gnEnsureFresh(REPO_ID, {
+      autoAnalyze: true,
+      requiredGraphCapabilities: ['symbols', 'impact', 'symbols', 'processes'],
+    });
+
+    expect(mockSubmitAnalysisJob.mock.calls[0][0].requestedCapabilities.graphCapabilities).toEqual([
+      'impact',
+      'processes',
+      'symbols',
+    ]);
+  });
+
+  it.each([{ capabilities: [] }, { capabilities: ['unknown'] }])(
+    'rejects invalid required graph capabilities ($capabilities)',
+    async ({ capabilities }) => {
+      await expect(
+        gnEnsureFresh(REPO_ID, { requiredGraphCapabilities: capabilities as any }),
+      ).rejects.toThrow(/requiredGraphCapabilities/);
+      expect(mockSubmitAnalysisJob).not.toHaveBeenCalled();
+    },
+  );
+
+  it('blocks managed embedding analysis without a model identity', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    delete process.env.ONTOINDEX_EMBEDDING_MODEL_HASH;
+
+    const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true, withEmbeddings: true });
+
+    expect(report.analysisSubmission).toMatchObject({
+      status: 'blocked',
+      reasonCode: 'EMBEDDING_MODEL_IDENTITY_UNAVAILABLE',
+    });
+    expect(mockComputeSourceManifest).not.toHaveBeenCalled();
+    expect(mockSubmitAnalysisJob).not.toHaveBeenCalled();
+  });
+
+  it('queues forced embeddings repair when HEAD is fresh but requested embeddings are missing', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockReadFileSync.mockReturnValue(
+      makeRegistry({ lastCommit: CURRENT_COMMIT, embeddings: 0 }) as any,
+    );
+    mockLoadMeta.mockResolvedValue(makeMeta({ embeddings: 0 }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, {
+      autoAnalyze: true,
+      withEmbeddings: true,
+    });
+
+    expect(mockSubmitAnalysisJob).toHaveBeenCalledTimes(1);
+    expect(mockSubmitAnalysisJob.mock.calls[0][0]).toMatchObject({
+      sourceIdentity: `commit:${CURRENT_COMMIT}`,
+      requestedCapabilities: { graph: true, embeddings: true },
+    });
+    expect(mockSubmitAnalysisJob.mock.calls[0][0].args).toEqual(
+      expect.arrayContaining(['analyze', '--force', '--embeddings']),
+    );
+    expect(report.analysisSubmission).toEqual({ status: 'queued', jobId: 'job-1' });
+    expect(report.actionsTaken[0]).toContain('analyze --force --embeddings');
+  });
+
+  it('does not submit analysis when HEAD and requested embeddings are already satisfied', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockReadFileSync.mockReturnValue(
+      makeRegistry({ lastCommit: CURRENT_COMMIT, embeddings: 12 }) as any,
+    );
+    mockLoadMeta.mockResolvedValue(makeMeta({ embeddings: 12 }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, {
+      autoAnalyze: true,
+      withEmbeddings: true,
+    });
+
+    expect(mockSubmitAnalysisJob).not.toHaveBeenCalled();
+    expect(mockComputeSourceManifest).not.toHaveBeenCalled();
+    expect(report.analysisSubmission).toEqual({ status: 'not-needed' });
+    expect(report.actionsTaken).toHaveLength(0);
+  });
+
+  it('blocks analysis when the worktree is dirty', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT, statusOutput: ' M src/edit.ts\n' });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
+
+    expect(mockSubmitAnalysisJob).not.toHaveBeenCalled();
+    expect(report.analysisSubmission).toMatchObject({
+      status: 'blocked',
+      reasonCode: 'WORKTREE_DIRTY',
+    });
+  });
+
+  it('blocks analysis when worktree status is unavailable', async () => {
+    mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, callback: any) => {
+      if (args.includes('HEAD') && args.includes('rev-parse')) {
+        callback(null, CURRENT_COMMIT + '\n', '');
+        return {} as any;
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        callback(new Error('status unavailable'), '', '');
+        return {} as any;
+      }
+      callback(null, '', '');
+      return {} as any;
+    });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
+
+    expect(mockSubmitAnalysisJob).not.toHaveBeenCalled();
+    expect(report.analysisSubmission).toMatchObject({
+      status: 'blocked',
+      reasonCode: 'WORKTREE_STATUS_UNAVAILABLE',
+    });
+  });
+
+  it.each(['', 'not-a-commit'])(
+    'blocks analysis when HEAD is unavailable or malformed (%s)',
+    async (head) => {
+      setupExecFile({ currentCommit: head });
+      mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+      mockReadRuntimeHealth.mockResolvedValue(makeRuntimeHealth('failed-after-partial-run'));
+
+      const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
+
+      expect(mockSubmitAnalysisJob).not.toHaveBeenCalled();
+      expect(report.analysisSubmission).toMatchObject({
+        status: 'blocked',
+        reasonCode: 'HEAD_UNAVAILABLE',
+      });
+    },
+  );
+
+  it('accepts a valid 64-character git HEAD for clean analysis submission', async () => {
+    const sha256Head = 'a'.repeat(64);
+    setupExecFile({ currentCommit: sha256Head });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
+
+    expect(mockSubmitAnalysisJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetHead: sha256Head,
+        sourceIdentity: `commit:${sha256Head}`,
+      }),
+    );
+    expect(report.analysisSubmission).toEqual({ status: 'queued', jobId: 'job-1' });
   });
 
   // ---- Test 5: embeddingsCount surfaced from registry ---------------------
@@ -592,6 +834,7 @@ describe('gnEnsureFresh', () => {
     setupExecFile({ currentCommit: CURRENT_COMMIT });
     mockSubmitAnalysisJob.mockRejectedValue(new Error('spawn failed'));
     mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
 
     const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
 
@@ -610,6 +853,7 @@ describe('gnEnsureFresh', () => {
       Object.assign(new Error('directory read'), { code: 'EISDIR' }),
     );
     mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
 
     const envelope = await gnEnsureFresh(REPO_ID, { autoAnalyze: true, legacyResponse: false });
 
@@ -622,10 +866,87 @@ describe('gnEnsureFresh', () => {
     });
   });
 
+  it('maps coordinator lock conflicts to a degraded blocked envelope', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockSubmitAnalysisJob.mockRejectedValue(
+      Object.assign(new Error('another managed analysis owns the lock'), { code: 'LOCK_CONFLICT' }),
+    );
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+
+    const envelope = await gnEnsureFresh(REPO_ID, { autoAnalyze: true, legacyResponse: false });
+
+    expect(envelope.status).toBe('degraded');
+    expect(envelope.results.analysisSubmission).toEqual({
+      status: 'blocked',
+      reasonCode: 'LOCK_CONFLICT',
+      message: 'another managed analysis owns the lock',
+    });
+    expect(envelope.warnings.join('\n')).not.toMatch(/delete.*lock/i);
+  });
+
+  it('maps active managed job conflicts to the existing job ID', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockSubmitAnalysisJob.mockRejectedValue(
+      Object.assign(new Error('an incompatible managed analysis is already active'), {
+        code: 'ACTIVE_JOB_CONFLICT',
+        activeJobId: 'job-active',
+      }),
+    );
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+
+    const envelope = await gnEnsureFresh(REPO_ID, { autoAnalyze: true, legacyResponse: false });
+
+    expect(envelope.status).toBe('degraded');
+    expect(envelope.results.analysisSubmission).toEqual({
+      status: 'blocked',
+      reasonCode: 'ACTIVE_JOB_CONFLICT',
+      message: 'an incompatible managed analysis is already active',
+      jobId: 'job-active',
+    });
+  });
+
+  it('reports an exact coordinator reuse as reused', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockSubmitAnalysisJob.mockResolvedValue({
+      reused: true,
+      job: {
+        version: 1,
+        id: 'job-reused',
+        status: 'running',
+        repoPath: REPO_PATH,
+        targetHead: CURRENT_COMMIT,
+        sourceIdentity: `commit:${CURRENT_COMMIT}`,
+        requestedCapabilities: {
+          version: 1,
+          graph: true,
+          graphCapabilities: ['symbols'],
+          embeddings: false,
+          embeddingModelHash: null,
+        },
+        optionsDigest: 'options-digest',
+        sourceManifestDigest: SOURCE_MANIFEST_DIGEST,
+        command: process.execPath,
+        args: ['analyze'],
+        logPath: `${REPO_PATH}/.ontoindex/analysis-jobs/job-reused.log`,
+        createdAt: '2026-08-05T00:00:00.000Z',
+      },
+    } as any);
+
+    const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
+
+    expect(report.analysisSubmission).toEqual({ status: 'reused', jobId: 'job-reused' });
+    expect(report.actionsTaken[0]).toContain('Reused analysis job job-reused');
+  });
+
   // ---- Test 9: killMcpForLock:true is advisory only → no process kill ----
   it('does not kill MCP processes when killMcpForLock:true', async () => {
     setupExecFile({ currentCommit: CURRENT_COMMIT });
     mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
 
     const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true, killMcpForLock: true });
 

--- a/ontoindex/test/unit/super/ensure-fresh.test.ts
+++ b/ontoindex/test/unit/super/ensure-fresh.test.ts
@@ -56,7 +56,7 @@ vi.mock('../../../src/mcp/shared/target-context.js', () => ({
 import { EventEmitter } from 'events';
 import { execFile, spawn } from 'child_process';
 import { readFileSync } from 'fs';
-import { gnEnsureFresh } from '../../../src/mcp/super/ensure-fresh.js';
+import { gnEnsureFresh, resetFreshnessCache } from '../../../src/mcp/super/ensure-fresh.js';
 import { readRuntimeHealth } from '../../../src/core/runtime/runtime-health.js';
 import {
   loadMeta,
@@ -231,6 +231,7 @@ function setupSpawnExit(code: number = 0) {
 describe('gnEnsureFresh', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetFreshnessCache();
     savedEnv = {};
     for (const key of Object.keys(process.env)) {
       if (key.startsWith('ONTOINDEX_')) {
@@ -972,5 +973,96 @@ describe('gnEnsureFresh', () => {
     expect(
       report.recommendations.some((r) => r.includes('no effect without autoAnalyze: true')),
     ).toBe(true);
+  });
+
+  // ---- Dirty-worktree breakdown ----
+  it('splits the dirty worktree into tracked and untracked counts', async () => {
+    setupExecFile({
+      currentCommit: CURRENT_COMMIT,
+      statusOutput: ' M src/edit.ts\n?? src/new-file.rs\n?? src/other.ts\n',
+    });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, {});
+
+    expect(report.dirtyFileCount).toBe(3);
+    expect(report.dirtyWorktreeBreakdown).toEqual({
+      trackedChangedCount: 1,
+      untrackedCount: 2,
+    });
+    expect(report.warnings.some((w) => w.includes('absent from the graph entirely'))).toBe(true);
+  });
+
+  it('agrees in number when exactly one file of each kind is present', async () => {
+    setupExecFile({
+      currentCommit: CURRENT_COMMIT,
+      statusOutput: ' M src/edit.ts\n?? src/new-file.rs\n',
+    });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, {});
+
+    const warning = report.warnings.find((w) => w.includes('absent from the graph entirely'));
+    expect(warning).toBe(
+      '1 untracked file is absent from the graph entirely; 1 tracked change is indexed at the indexed commit.',
+    );
+  });
+
+  it('reports a clean worktree with zeroed breakdown and no untracked warning', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, {});
+
+    expect(report.dirtyWorktreeBreakdown).toEqual({
+      trackedChangedCount: 0,
+      untrackedCount: 0,
+    });
+    expect(report.warnings.some((w) => w.includes('absent from the graph entirely'))).toBe(false);
+  });
+
+  it('explains why a dirty worktree blocks managed analysis', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT, statusOutput: ' M src/edit.ts\n' });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+
+    const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
+
+    expect(report.analysisSubmission).toMatchObject({ reasonCode: 'WORKTREE_DIRTY' });
+    const message = (report.analysisSubmission as { message: string }).message;
+    expect(message).toContain(`commit:${CURRENT_COMMIT}`);
+    expect(report.recommendations.some((r) => r.includes('Commit or stash'))).toBe(true);
+  });
+
+  // ---- Read-only freshness caching ----
+  it('serves repeated read-only probes from cache and re-probes after reset', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+
+    const first = await gnEnsureFresh(REPO_ID, {});
+    const revParseCalls = () =>
+      mockExecFile.mock.calls.filter((call) => (call[1] as string[]).includes('rev-parse')).length;
+    const afterFirst = revParseCalls();
+    const second = await gnEnsureFresh(REPO_ID, {});
+
+    expect(second).toEqual(first);
+    expect(revParseCalls()).toBe(afterFirst);
+
+    resetFreshnessCache();
+    await gnEnsureFresh(REPO_ID, {});
+    expect(revParseCalls()).toBeGreaterThan(afterFirst);
+  });
+
+  it('never serves an autoAnalyze request from cache', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT, statusOutput: ' M src/edit.ts\n' });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+
+    await gnEnsureFresh(REPO_ID, {});
+    const revParseCalls = () =>
+      mockExecFile.mock.calls.filter((call) => (call[1] as string[]).includes('rev-parse')).length;
+    const afterReadOnly = revParseCalls();
+
+    await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
+
+    expect(revParseCalls()).toBeGreaterThan(afterReadOnly);
   });
 });

--- a/ontoindex/test/unit/super/ensure-fresh.test.ts
+++ b/ontoindex/test/unit/super/ensure-fresh.test.ts
@@ -655,17 +655,28 @@ describe('gnEnsureFresh', () => {
     expect(report.actionsTaken).toHaveLength(0);
   });
 
-  it('blocks analysis when the worktree is dirty', async () => {
+  it('submits analysis for a dirty worktree under working-tree source identity', async () => {
     setupExecFile({ currentCommit: CURRENT_COMMIT, statusOutput: ' M src/edit.ts\n' });
     mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
 
     const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
 
-    expect(mockSubmitAnalysisJob).not.toHaveBeenCalled();
-    expect(report.analysisSubmission).toMatchObject({
-      status: 'blocked',
-      reasonCode: 'WORKTREE_DIRTY',
-    });
+    expect(mockSubmitAnalysisJob).toHaveBeenCalledTimes(1);
+    const submission = mockSubmitAnalysisJob.mock.calls[0][0];
+    expect(submission.sourceIdentity).toBe(`worktree:${submission.sourceManifestDigest}`);
+    expect(submission.targetHead).toBe(CURRENT_COMMIT);
+    expect(report.analysisSubmission).not.toMatchObject({ status: 'blocked' });
+  });
+
+  it('keeps commit source identity when the worktree is clean', async () => {
+    setupExecFile({ currentCommit: CURRENT_COMMIT });
+    mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
+    mockLoadMeta.mockResolvedValue(makeMeta({ lastCommit: STALE_INDEXED_COMMIT }) as any);
+
+    await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
+
+    expect(mockSubmitAnalysisJob).toHaveBeenCalledTimes(1);
+    expect(mockSubmitAnalysisJob.mock.calls[0][0].sourceIdentity).toBe(`commit:${CURRENT_COMMIT}`);
   });
 
   it('blocks analysis when worktree status is unavailable', async () => {
@@ -1021,16 +1032,17 @@ describe('gnEnsureFresh', () => {
     expect(report.warnings.some((w) => w.includes('absent from the graph entirely'))).toBe(false);
   });
 
-  it('explains why a dirty worktree blocks managed analysis', async () => {
+  it('warns that dirty analysis is not published under the commit identity', async () => {
     setupExecFile({ currentCommit: CURRENT_COMMIT, statusOutput: ' M src/edit.ts\n' });
     mockReadFileSync.mockReturnValue(makeRegistry({ lastCommit: CURRENT_COMMIT }) as any);
 
     const report = await gnEnsureFresh(REPO_ID, { autoAnalyze: true });
 
-    expect(report.analysisSubmission).toMatchObject({ reasonCode: 'WORKTREE_DIRTY' });
-    const message = (report.analysisSubmission as { message: string }).message;
-    expect(message).toContain(`commit:${CURRENT_COMMIT}`);
-    expect(report.recommendations.some((r) => r.includes('Commit or stash'))).toBe(true);
+    expect(
+      report.warnings.some(
+        (w) => w.includes('working-tree identity') && w.includes('uncommitted change'),
+      ),
+    ).toBe(true);
   });
 
   // ---- Read-only freshness caching ----

--- a/ontoindex/test/unit/super/safe-edit-check.test.ts
+++ b/ontoindex/test/unit/super/safe-edit-check.test.ts
@@ -711,9 +711,9 @@ describe('gnSafeEditCheck', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Additional: symbol not found returns safe report with warning
+  // Additional: symbol not found must not yield the most permissive verdict
   // -------------------------------------------------------------------------
-  it('returns SAFE with warning when symbol is not found in index', async () => {
+  it('returns CAUTION with warning when symbol is not found in index', async () => {
     // resolveSymbol returns empty
     mockExecuteParameterized.mockResolvedValueOnce([]); // canonical lookup → 0 rows
     mockFindTestFiles.mockResolvedValue({ coveringTests: [], likelihoodOfCoverage: 'NONE' });
@@ -721,10 +721,26 @@ describe('gnSafeEditCheck', () => {
 
     const report = await gnSafeEditCheck(REPO_ID, { symbol: 'unknownSymbol' });
 
-    expect(report.verdict).toBe('SAFE');
+    expect(report.verdict).toBe('CAUTION');
     expect(report.warnings).toContain('symbol not found in index');
     expect(report.symbol.nodeId).toBe('');
     expect(report.rawCounts).toBeUndefined();
+    expect(report.preChecks).toContainEqual(
+      expect.objectContaining({ check: 'symbol_in_index', passed: false }),
+    );
+  });
+
+  it('does not report a delete-intent unknown symbol as SAFE', async () => {
+    mockExecuteParameterized.mockResolvedValueOnce([]);
+    mockFindTestFiles.mockResolvedValue({ coveringTests: [], likelihoodOfCoverage: 'NONE' });
+    mockGetClient.mockResolvedValue(null);
+
+    const report = await gnSafeEditCheck(REPO_ID, {
+      symbol: 'definitely_not_a_real_symbol',
+      intent: 'delete',
+    });
+
+    expect(report.verdict).not.toBe('SAFE');
   });
 
   // -------------------------------------------------------------------------

--- a/ontoindex/test/unit/target-context.test.ts
+++ b/ontoindex/test/unit/target-context.test.ts
@@ -126,6 +126,80 @@ describe('resolveTargetContext', () => {
     expect(context.dirtyWorkspace?.state).toBe('stale-index');
   });
 
+  it('uses active generation metadata when the registry commit lags', async () => {
+    const { resolveTargetContext } = await loadActualResolver();
+    const registryCommit = 'def456abc123def456abc123def456abc123def4';
+
+    const context = await resolveTargetContext(
+      { repo: REPO_ID, verifyGraphAuthority: true },
+      {
+        readRegistry: async () => [{ ...registryEntry, lastCommit: registryCommit }],
+        execGit: execGitFor(CURRENT_COMMIT),
+        loadMeta: async () => ({
+          repoPath: '.',
+          lastCommit: CURRENT_COMMIT,
+          indexedAt: 'graph-index-1',
+          generationId: 'generation-1',
+          model_hash: 'sha256:model-a',
+          sourceManifest: manifest,
+        }),
+        resolveActiveIndexGeneration: async () => ({
+          generationId: 'generation-1',
+          generationPath: '/repo/test-repo/.ontoindex/generations/generation-1',
+          lbugPath: '/repo/test-repo/.ontoindex/generations/generation-1/lbug',
+          metaPath: '/repo/test-repo/.ontoindex/generations/generation-1/meta.json',
+          snapshotPath: '/repo/test-repo/.ontoindex/generations/generation-1/snapshot.json',
+        }),
+        computeSourceManifest: async () => manifest,
+      },
+    );
+
+    expect(context.indexedHead).toBe(CURRENT_COMMIT);
+    expect(context.changedSinceIndex).toBe(false);
+    expect(context.embeddings.modelHash).toBe('sha256:model-a');
+    expect(context.graphAuthority).toMatchObject({ state: 'authoritative' });
+    expect(context.warnings).toContain(
+      `Registry commit ${registryCommit} lags trusted index metadata ${CURRENT_COMMIT}; using trusted metadata as indexed-head authority.`,
+    );
+  });
+
+  it('keeps registry commit authority when metadata does not match the active generation', async () => {
+    const { resolveTargetContext } = await loadActualResolver();
+    const registryCommit = 'def456abc123def456abc123def456abc123def4';
+
+    const context = await resolveTargetContext(
+      { repo: REPO_ID, verifyGraphAuthority: true },
+      {
+        readRegistry: async () => [{ ...registryEntry, lastCommit: registryCommit }],
+        execGit: execGitFor(CURRENT_COMMIT),
+        loadMeta: async () => ({
+          repoPath: '.',
+          lastCommit: CURRENT_COMMIT,
+          indexedAt: 'graph-index-1',
+          generationId: 'generation-meta',
+          model_hash: 'sha256:untrusted-model',
+          sourceManifest: manifest,
+        }),
+        resolveActiveIndexGeneration: async () => ({
+          generationId: 'generation-active',
+          generationPath: '/repo/test-repo/.ontoindex/generations/generation-active',
+          lbugPath: '/repo/test-repo/.ontoindex/generations/generation-active/lbug',
+          metaPath: '/repo/test-repo/.ontoindex/generations/generation-active/meta.json',
+          snapshotPath: '/repo/test-repo/.ontoindex/generations/generation-active/snapshot.json',
+        }),
+      },
+    );
+
+    expect(context.indexedHead).toBe(registryCommit);
+    expect(context.changedSinceIndex).toBe(true);
+    expect(context.graphAuthority).toMatchObject({
+      state: 'degraded',
+      reason: 'active graph generation does not match metadata generation',
+    });
+    expect(context.warnings.join('\n')).not.toContain('indexed-head authority');
+    expect(context.embeddings).not.toHaveProperty('modelHash');
+  });
+
   it('marks dirty worktree as dirty overlay snapshot', async () => {
     const { resolveTargetContext } = await loadActualResolver();
 

--- a/release-notes-v2.2.0.md
+++ b/release-notes-v2.2.0.md
@@ -1,0 +1,44 @@
+# OntoIndex 2.2.0
+
+OntoIndex 2.2.0 strengthens two trust boundaries: audit-history integrity and
+managed analysis publication.
+
+## Highlights
+
+- Audit event stores now carry a tamper-evident checksum chain. Trust-sensitive
+  dispatch fails closed when that chain is broken or legacy history cannot be
+  verified, while read-only investigation remains available.
+- `ontoindex audit integrity` verifies the event store without mutation. An
+  archive-and-reset recovery path requires explicit data-loss acknowledgement
+  and preserves the original bytes.
+- Managed analysis jobs now carry exact source and capability identity and emit
+  a job-bound publication receipt.
+- `gn_ensure_fresh` classifies prerequisites and submits or reuses exact jobs;
+  `gn_analyze_job` proves terminal recovery with the publication receipt and a
+  final capability-aware freshness check.
+- Missing required embeddings can trigger managed recovery even when the graph
+  already targets the current HEAD.
+- Generation activation, publication commit, and rollback are one serialized
+  transaction. Failed commits restore the previous generation or remove the
+  first-generation pointer without deleting diagnostic output.
+
+## Recovery Contract
+
+`gn_ensure_fresh` returns structured submission outcomes. A returned job must
+be observed through `gn_analyze_job`, whose recovery disposition is one of:
+
+- `REFRESH_RUNNING` — the exact managed job is still queued or running;
+- `REFRESHED` — receipt, active generation, repository, HEAD, graph authority,
+  and requested capabilities all match;
+- `FAILED` — submission, execution, cancellation, or publication failed;
+- `FRESHNESS_UNCONFIRMED` — execution apparently completed, but publication or
+  the final freshness postcondition could not be proven.
+
+Clients must not delete analyzer locks and must retry the original graph request
+unchanged only after `REFRESHED`.
+
+## Distribution
+
+This release is distributed as the installable GitHub asset
+`ontoindex-2.2.0.tgz` under tag `github-release/2.2.0`. It is intentionally not
+published to the public npm registry and does not create 2.2.0 container tags.

--- a/release-notes-v2.2.0.md
+++ b/release-notes-v2.2.0.md
@@ -1,7 +1,7 @@
 # OntoIndex 2.2.0
 
-OntoIndex 2.2.0 strengthens two trust boundaries: audit-history integrity and
-managed analysis publication.
+OntoIndex 2.2.0 strengthens audit-history integrity, managed analysis publication,
+and the read-only diagnostics used to decide when those workflows are safe.
 
 ## Highlights
 
@@ -21,6 +21,11 @@ managed analysis publication.
 - Generation activation, publication commit, and rollback are one serialized
   transaction. Failed commits restore the previous generation or remove the
   first-generation pointer without deleting diagnostic output.
+- Read-only freshness probes use a short bounded cache, report tracked versus
+  untracked worktree changes, and never cache managed analysis requests.
+- Diagnostics no longer advertise managed refresh while the worktree is dirty,
+  and unknown symbols return `CAUTION` instead of treating missing graph evidence
+  as proof of edit safety.
 
 ## Recovery Contract
 
@@ -40,5 +45,6 @@ unchanged only after `REFRESHED`.
 ## Distribution
 
 This release is distributed as the installable GitHub asset
-`ontoindex-2.2.0.tgz` under tag `github-release/2.2.0`. It is intentionally not
-published to the public npm registry and does not create 2.2.0 container tags.
+`ontoindex-2.2.0.tgz` under the GitHub-only tag `github-release/2.2.0-r1`. It is
+intentionally not published to the public npm registry and does not create 2.2.0
+container tags.

--- a/release-notes-v2.2.1.md
+++ b/release-notes-v2.2.1.md
@@ -1,0 +1,26 @@
+# OntoIndex 2.2.1
+
+OntoIndex 2.2.1 fixes managed analysis for repositories with uncommitted
+changes. A dirty worktree can now be refreshed without falsely identifying its
+indexed bytes as a clean commit.
+
+## Highlights
+
+- Dirty-worktree analysis uses `worktree:<source-manifest-digest>` as its source
+  identity. The digest represents the exact file contents submitted for
+  analysis.
+- Clean analysis retains the existing `commit:<HEAD>` identity.
+- `gn_ensure_fresh({ autoAnalyze: true })` can submit analysis for a dirty
+  worktree instead of blocking it solely because uncommitted changes exist.
+- Dirty source is considered refreshable even when the graph already targets
+  the current commit.
+- The source identity is validated consistently across job submission, runner
+  environment, publication receipts, and `gn_analyze_job` recovery.
+- Recovery still fails closed when a source identity does not match either the
+  target commit or the analyzed source-manifest digest.
+
+## Distribution
+
+This release is distributed as the installable GitHub asset
+`ontoindex-2.2.1.tgz` under the GitHub-only tag `github-release/2.2.1`. It is not
+published to the public npm registry and does not create new container tags.


### PR DESCRIPTION
## What changed

Persisted audit events now carry a monotonic `sequence`, a `previousChecksum` link, and a SHA-256 `checksum` over versioned canonical JSON, so interior mutation, insertion, and reordering are detected at the first affected sequence. Trust-sensitive dispatch fails closed unless the retained chain verifies completely; read-only diff, replay, and export remain available with an explicit integrity status.

Schema-v1 stores are read-only. They report `LEGACY_UNVERIFIED` and refuse appends and direct saves rather than being migrated in place. `ontoindex audit integrity` adds read-only verification plus an archive-and-reset path gated behind both `--reset-broken` and `--acknowledge-data-loss`.

## Why

Review reproduced two trust bypasses against the delivered code:

1. Changing only `schemaVersion` to `1` suppressed verification of a tampered schema-v2 store, and both dispatch entry points accepted it.
2. Stripping every integrity envelope produced `LEGACY_UNVERIFIED`, and one ordinary append re-signed the tampered history as dispatchable, with the forged content intact.

The root cause of the second was in-place migration granting trust by position. Removing it closes the path rather than guarding it.

## How to verify

```bash
cd ontoindex
npx vitest run
npx tsc --noEmit
npm publish --dry-run
```

Full suite: 9503 passed across 537 files. Attack replays now refuse at every step, and healthy dispatch still succeeds.

## Risk and rollback

**Breaking for existing v1 stores:** a legacy store can no longer carry its history forward. Archive-and-reset plus re-ingest is the only path. This is deliberate: unverified history confers no dispatch trust.

Rollback means reverting the audit-lifecycle, MCP, and CLI changes together; the laundering path returns, so do not roll back without an alternative gate.

ADR section 3 amended to match. Rollback and valid-tail deletion remain undetectable without an independent trust anchor, as before.
