### PR TITLE
fix(skills): use callable tool names and install skills for Ontocode

### DIFF
--- a/.cursor/index.mdc
+++ b/.cursor/index.mdc
@@ -10,9 +10,9 @@ Canonical agent instructions: **[AGENTS.md](../AGENTS.md)** (OntoIndex MCP rules
 
 ## Non-negotiables (always apply)
 
-- NEVER edit a function/class/method without running `ontoindex_impact` first.
-- NEVER rename symbols with find-and-replace — use `ontoindex_rename`.
-- NEVER commit without running `ontoindex_detect_changes()`.
+- NEVER edit a function/class/method without running `impact({action: "symbol", ...})` first.
+- NEVER rename symbols with find-and-replace — use `refactor({action: "rename", ...})`.
+- NEVER commit without running `gn_verify_diff({repo, scope: "all"})`.
 - NEVER ignore HIGH/CRITICAL risk warnings from impact analysis.
 - NEVER run `npx ontoindex analyze` without `--embeddings` if `.ontoindex/meta.json` shows stored embeddings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to OntoIndex will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `ontoindex setup` now installs skills into `~/.ontocode/skills/` for Ontocode, which previously
+  received MCP configuration, agent guidance, and hooks but never had its skill copies refreshed.
+- The Linux/macOS and Windows installers now run `ontoindex setup` after a validated install, so
+  skills and MCP client configuration are in place without a second manual command. Setup failures
+  are reported as warnings and do not fail the install. Set `ONTOINDEX_SKIP_SETUP=1` to opt out.
+
+### Fixed
+
+- Corrected the OntoIndex skills to use callable tool names. They documented `ontoindex_query`,
+  `ontoindex_context`, `ontoindex_impact`, `ontoindex_rename`, and `ontoindex_detect_changes`,
+  none of which exist in the 2.x MCP surface. They now use the `search`, `inspect`, `impact`, and
+  `refactor` facades and the `gn_*` tools, verified against `gn_tool_contract`.
+- Replaced the "WILL BREAK" label on direct dependents in impact and PR-review guidance. Dependency
+  distance is review priority, not proof of breakage, and the previous wording caused agents to
+  report unverified regressions.
+- Added explicit missing-tool handling to the skills so an agent reports an unavailable OntoIndex
+  tool instead of presenting grep results as graph-backed evidence.
+- Documented that the `ontoindex` facade dispatcher is advertised but not callable in the default
+  `public-full` startup profile.
+
 ## [2.1.5] - 2026-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ iwr -useb https://raw.githubusercontent.com/ontograph/ontoindex/master/scripts/i
 ontoindex --version
 ```
 
+Both installers run `ontoindex setup` after a validated install, so MCP client
+configuration, agent guidance, and skills are in place without a second command.
+Setup is idempotent, and a setup failure does not fail the install. Set
+`ONTOINDEX_SKIP_SETUP=1` to install without it. Restart your editor or agent
+client afterwards so it loads the OntoIndex MCP server.
+
 Windows note:
 
 - OntoIndex no longer supports Node.js 20 in the current release line because `commander@15`
@@ -136,6 +142,7 @@ Installer configuration:
 | Force user prefix              | `ONTOINDEX_NPM_PREFIX="$HOME/.local" ./scripts/install-ontoindex-latest.sh`    | `.\scripts\install-ontoindex-latest.ps1 -ForceUserPrefix`                              |
 | Require FTS/vector cache prefetch | `ONTOINDEX_REQUIRE_LADYBUG_EXTENSIONS=1 ./scripts/install-ontoindex-latest.sh` | `$env:ONTOINDEX_REQUIRE_LADYBUG_EXTENSIONS='1'; .\scripts\install-ontoindex-latest.ps1` |
 | Skip FTS/vector cache prefetch    | `ONTOINDEX_SKIP_LADYBUG_EXTENSIONS=1 ./scripts/install-ontoindex-latest.sh`    | `$env:ONTOINDEX_SKIP_LADYBUG_EXTENSIONS='1'; .\scripts\install-ontoindex-latest.ps1`    |
+| Skip `ontoindex setup` after install | `ONTOINDEX_SKIP_SETUP=1 ./scripts/install-ontoindex-latest.sh`              | `$env:ONTOINDEX_SKIP_SETUP='1'; .\scripts\install-ontoindex-latest.ps1`                |
 
 ### Install with npm
 
@@ -218,6 +225,13 @@ normalization or call the tool as `name="inspect"` with `namespace="mcp__ontoind
 ## MCP Setup
 
 `ontoindex setup` configures supported MCP clients automatically. Manual examples are useful for debugging or for clients that do not support automatic setup.
+
+Alongside MCP configuration, `ontoindex setup` installs the OntoIndex skills for
+the clients it detects: `~/.claude/skills/`, `~/.cursor/skills/`,
+`~/.agents/skills/` for Codex, `~/.config/opencode/skill/` for OpenCode, and
+`~/.ontocode/skills/` for Ontocode. Rerun `ontoindex setup` after upgrading so
+those copies match the installed tool contract; a client that keeps stale skill
+files will call tool names that no longer exist.
 
 | Client         | Linux/macOS                                   | Windows PowerShell                            |
 | -------------- | --------------------------------------------- | --------------------------------------------- |

--- a/ontoindex-claude-plugin/skills/ontoindex-cli/SKILL.md
+++ b/ontoindex-claude-plugin/skills/ontoindex-cli/SKILL.md
@@ -5,7 +5,26 @@ description: "Use when the user needs to run OntoIndex CLI commands like analyze
 
 # OntoIndex CLI Commands
 
-All commands work via `npx` — no global install required.
+Use the installed `ontoindex` binary when it is on PATH; otherwise `npx
+ontoindex` works without a global install. Verified against OntoIndex 2.2.0.
+
+## MCP Availability
+
+When OntoIndex is required but no OntoIndex tool is callable in the session,
+treat it as a tooling failure and repair it before graph-backed work:
+
+```bash
+ontoindex mcp-doctor --repo <repo>   # verdict, freshness, and exact repair command
+ontoindex setup                      # register MCP for supported clients
+```
+
+`mcp-doctor` reports whether an MCP process is running, whether the resource
+bridge is exposed, and which repair command to run. After `setup` writes the
+client configuration, the client must be restarted to load the server.
+
+The `ontoindex` facade dispatcher is advertised but not callable in the default
+`public-full` startup profile. Use the `search`, `inspect`, `impact`, and
+`refactor` facades or the `gn_*` tools.
 
 ## Commands
 
@@ -17,12 +36,12 @@ npx ontoindex analyze
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.ontoindex/`, and generates CLAUDE.md / AGENTS.md context files.
 
-| Flag | Effect |
-|------|--------|
-| `--force` | Force full re-index even if up to date |
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
 | `--embeddings` | Enable embedding generation for semantic search (off by default) |
 
-**When to run:** First time in a project, after major code changes, or when `ontoindex://repo/{name}/context` reports the index is stale.
+**When to run:** First time in a project, after major code changes, or when `ontoindex://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
 
 ### status — Check index freshness
 
@@ -40,10 +59,10 @@ npx ontoindex clean
 
 Deletes the `.ontoindex/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing OntoIndex from a project.
 
-| Flag | Effect |
-|------|--------|
-| `--force` | Skip confirmation prompt |
-| `--all` | Clean all indexed repos, not just the current one |
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
 
 ### wiki — Generate documentation from the graph
 
@@ -53,14 +72,14 @@ npx ontoindex wiki
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.ontoindex/config.json` on first use).
 
-| Flag | Effect |
-|------|--------|
-| `--force` | Force full regeneration |
-| `--model <model>` | LLM model (default: minimax/minimax-m2.5) |
-| `--base-url <url>` | LLM API base URL |
-| `--api-key <key>` | LLM API key |
-| `--concurrency <n>` | Parallel LLM calls (default: 3) |
-| `--gist` | Publish wiki as a public GitHub Gist |
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
 
 ### list — Show all indexed repos
 
@@ -75,8 +94,39 @@ Lists all repositories registered in `~/.ontoindex/registry.json`. The MCP `list
 1. **Read `ontoindex://repo/{name}/context`** to verify the index loaded
 2. Use the other OntoIndex skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
 
+## Stale-Index Recovery
+
+When an OntoIndex query reports a stale index or cannot resolve a symbol that
+exists in current source:
+
+1. Preserve the blocked query and its arguments.
+2. Check freshness with `gn_ensure_fresh`. If the index is current, return to
+   the query instead of starting analysis.
+3. Before refresh, inspect `.ontoindex/analyze.lock`. Never start a second
+   analysis while its recorded PID is alive. Clear the lock only after proving
+   that PID is dead.
+4. Submit one background refresh with `gn_ensure_fresh(autoAnalyze=true)` and
+   observe it with `gn_analyze_job`. For an Axel CLI refresh already running by
+   PID and log, route monitoring through `axel-background-job-watch`.
+5. Accept refresh only after the job exits successfully and
+   `gn_ensure_fresh` reports the expected freshness state. Dirty-worktree
+   freshness is valid only for claims checked against current source or diff.
+6. Retry the blocked graph query once with its original arguments. Report the
+   refresh evidence and keep unresolved results provisional.
+
+Do not request embeddings unless the blocked operation requires semantic or
+vector retrieval. Graph impact and traversal need only the normal index.
+
 ## Troubleshooting
 
 - **"Not inside a git repository"**: Run from a directory inside a git repo
 - **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
 - **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding
+
+## Routine Tool Ownership
+
+This skill owns routine-tool operation 39, `ONTOINDEX_FRESH_GATE`, in
+`~/.ontocode/skills/ontocode-routine-tools/references/tool-catalog.md`. The gate
+must verify commit/index/job/publication identity and fail closed before graph
+queries when freshness cannot be proven. Return the coordinator's shared
+envelope.

--- a/ontoindex-claude-plugin/skills/ontoindex-debugging/SKILL.md
+++ b/ontoindex-claude-plugin/skills/ontoindex-debugging/SKILL.md
@@ -16,23 +16,28 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 ## Workflow
 
 ```
-1. ontoindex_query({query: "<error or symptom>"})            → Find related execution flows
-2. ontoindex_context({name: "<suspect>"})                    → See callers/callees/processes
-3. READ ontoindex://repo/{name}/process/{name}                → Trace execution flow
-4. ontoindex_cypher({query: "MATCH path..."})                 → Custom traces if needed
+1. gn_ensure_fresh({repo})                                   → Check freshness first
+2. search({action: "semantic", repo, query: "<symptom>"})    → Find related execution flows
+3. inspect({action: "context", repo, target: "<suspect>"})   → See callers/callees/processes
+4. gn_diagnose({repo}) / gn_error_topology({repo})           → Failure-path evidence
+5. Read source files to confirm the root cause
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+A dirty worktree is not represented in the graph. Confirm any suspect code
+against current source before concluding a root cause. If OntoIndex is required
+but not callable, report the missing tool instead of substituting grep.
 
 ## Checklist
 
 ```
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] ontoindex_query for error text or related code
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] search({action: "semantic"}) for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] ontoindex_context to see callers and callees
-- [ ] Trace execution flow via process resource if applicable
-- [ ] ontoindex_cypher for custom call chain traces if needed
+- [ ] inspect({action: "context"}) to see callers and callees
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,50 +45,45 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | OntoIndex Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `ontoindex_query` for error text → `context` on throw sites |
-| Wrong return value   | `context` on the function → trace callees for data flow    |
-| Intermittent failure | `context` → look for external calls, async deps            |
-| Performance issue    | `context` → find symbols with many callers (hot paths)     |
-| Recent regression    | `detect_changes` to see what your changes affect           |
+| Error message        | `search` for error text → `inspect` on throw sites          |
+| Wrong return value   | `inspect` on the function → trace callees for data flow     |
+| Intermittent failure | `inspect` → look for external calls, async deps             |
+| Performance issue    | `inspect` → find symbols with many callers (hot paths)      |
+| Recent regression    | `gn_verify_diff` to see what your changes affect            |
 
 ## Tools
 
-**ontoindex_query** — find code related to error:
+**search** — find code related to error:
 
 ```
-ontoindex_query({query: "payment validation error"})
+search({action: "semantic", repo: "<repo>", query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**ontoindex_context** — full context for a suspect:
+**inspect** — full context for a suspect:
 
 ```
-ontoindex_context({name: "validatePayment"})
+inspect({action: "context", repo: "<repo>", target: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**ontoindex_cypher** — custom call chain traces:
-
-```cypher
-MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
-RETURN [n IN nodes(path) | n.name] AS chain
-```
+**gn_graph_walk / gn_trace_boundary** — custom call chain and boundary traces
+when `search` and `inspect` do not isolate the path.
 
 ## Example: "Payment endpoint returns 500 intermittently"
 
 ```
-1. ontoindex_query({query: "payment error handling"})
+1. search({action: "semantic", repo: "my-app", query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. ontoindex_context({name: "validatePayment"})
+2. inspect({action: "context", repo: "my-app", target: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
-3. READ ontoindex://repo/my-app/process/CheckoutFlow
-   → Step 3: validatePayment → calls fetchRates (external)
+3. Read the fetchRates source to confirm the timeout behavior
 
 4. Root cause: fetchRates calls external API without proper timeout
 ```

--- a/ontoindex-claude-plugin/skills/ontoindex-exploring/SKILL.md
+++ b/ontoindex-claude-plugin/skills/ontoindex-exploring/SKILL.md
@@ -16,24 +16,29 @@ description: "Use when the user asks how code works, wants to understand archite
 ## Workflow
 
 ```
-1. READ ontoindex://repos                          → Discover indexed repos
-2. READ ontoindex://repo/{name}/context             → Codebase overview, check staleness
-3. ontoindex_query({query: "<what you want to understand>"})  → Find related execution flows
-4. ontoindex_context({name: "<symbol>"})            → Deep dive on specific symbol
-5. READ ontoindex://repo/{name}/process/{name}      → Trace full execution flow
+1. gn_ensure_fresh({repo})                                   → Check freshness first
+2. search({action: "semantic", repo, query: "<concept>"})    → Find related execution flows
+3. inspect({action: "context", repo, target: "<symbol>"})    → Deep dive on a symbol
+4. gn_explain_module({repo, module})                         → Module-level overview
+5. Read source files for implementation details
 ```
 
-> If step 2 says "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+Prefer graph search over grep for discovery. If OntoIndex is required but not
+callable, say so explicitly rather than presenting grep results as
+graph-backed evidence.
 
 ## Checklist
 
 ```
-- [ ] READ ontoindex://repo/{name}/context
-- [ ] ontoindex_query for the concept you want to understand
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] search({action: "semantic"}) for the concept
 - [ ] Review returned processes (execution flows)
-- [ ] ontoindex_context on key symbols for callers/callees
-- [ ] READ process resource for full execution traces
+- [ ] inspect({action: "context"}) on key symbols for callers/callees
 - [ ] Read source files for implementation details
+- [ ] Verify uncommitted changes against current source, not the graph
 ```
 
 ## Resources
@@ -47,18 +52,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**ontoindex_query** — find execution flows related to a concept:
+**search** — find execution flows related to a concept:
 
 ```
-ontoindex_query({query: "payment processing"})
+search({action: "semantic", repo: "<repo>", query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**ontoindex_context** — 360-degree view of a symbol:
+**inspect** — 360-degree view of a symbol:
 
 ```
-ontoindex_context({name: "validateUser"})
+inspect({action: "context", repo: "<repo>", target: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -67,11 +72,11 @@ ontoindex_context({name: "validateUser"})
 ## Example: "How does payment processing work?"
 
 ```
-1. READ ontoindex://repo/my-app/context       → 918 symbols, 45 processes
-2. ontoindex_query({query: "payment processing"})
+1. gn_ensure_fresh({repo: "my-app"})          → fresh
+2. search({action: "semantic", repo: "my-app", query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. ontoindex_context({name: "processPayment"})
+3. inspect({action: "context", repo: "my-app", target: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/ontoindex-claude-plugin/skills/ontoindex-guide/SKILL.md
+++ b/ontoindex-claude-plugin/skills/ontoindex-guide/SKILL.md
@@ -7,15 +7,50 @@ description: "Use when the user asks about OntoIndex itself — available tools,
 
 Quick reference for all OntoIndex MCP tools, resources, and the knowledge graph schema.
 
+Verified against OntoIndex 2.2.0 on 2026-09-05 by calling the running MCP
+server (`gn_tool_contract`).
+
 ## Always Start Here
 
 For any task involving code understanding, debugging, impact analysis, or refactoring:
 
-1. **Read `ontoindex://repo/{name}/context`** — codebase overview + check index freshness
+1. **Check freshness** with `gn_ensure_fresh({repo})` before any graph-backed claim.
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx ontoindex analyze` in the terminal first.
+If OntoIndex is required but no OntoIndex tool is callable, stop and report the
+missing tool. Do not silently fall back to grep-only inspection and present the
+result as graph-backed evidence. Repair with `ontoindex mcp-doctor` and
+`ontoindex setup`, then confirm the tools are callable.
+
+> If freshness reports stale, refresh with `ontoindex analyze`. See
+> `ontoindex-cli` for the single-owner lock and job rules.
+
+## Tool Naming
+
+Two callable surfaces exist. Both are served by the same MCP server.
+
+- Facade tools take an `action`: `search`, `inspect`, `impact`, `refactor`,
+  `audit`, `docs`, `discover`, `manage`.
+- Compatibility tools are the 54 `gn_*` tools, such as `gn_explore`,
+  `gn_ensure_fresh`, `gn_verify_diff`, and `gn_safe_edit_check`.
+
+The `ontoindex` dispatcher tool is advertised by the registry but is **not**
+callable in the default `public-full` startup profile; calling it returns
+`Unknown tool method: ontoindex`. Use a facade or `gn_*` tool instead.
+
+Verified callable examples:
+
+```
+search({action: "semantic", repo: "<repo>", query: "concept"})
+inspect({action: "context", repo: "<repo>", target: "symbolName"})
+impact({action: "symbol", repo: "<repo>", target: "symbolName", direction: "upstream"})
+gn_ensure_fresh({repo: "<repo>"})
+```
+
+Older `ontoindex_query`, `ontoindex_context`, `ontoindex_impact`,
+`ontoindex_rename`, and `ontoindex_detect_changes` names are **not** callable in
+2.2.0. Use the facade or `gn_*` equivalents below.
 
 ## Skills
 
@@ -30,19 +65,26 @@ For any task involving code understanding, debugging, impact analysis, or refact
 
 ## Tools Reference
 
-| Tool             | What it gives you                                                        |
-| ---------------- | ------------------------------------------------------------------------ |
-| `query`          | Process-grouped code intelligence — execution flows related to a concept |
-| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
-| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
-| `detect_changes` | Git-diff impact — what do your current changes affect                    |
-| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
-| `cypher`         | Raw graph queries (read `ontoindex://repo/{name}/schema` first)           |
-| `list_repos`     | Discover indexed repos                                                   |
+| Intent                  | Callable tool                                     |
+| ----------------------- | ------------------------------------------------- |
+| Find execution flows    | `search({action: "semantic"})` or `gn_explore`     |
+| Symbol callers/callees  | `inspect({action: "context"})` or `gn_find_related`|
+| Blast radius            | `impact({action: "symbol"})`                       |
+| Pre-edit safety check   | `gn_safe_edit_check`                               |
+| Diff/commit verification| `gn_verify_diff`, `gn_diff_impact`                 |
+| Coordinated rename      | `refactor({action: "rename"})`, `gn_safe_refactor` |
+| Index freshness         | `gn_ensure_fresh`, `gn_analyze_job`                |
+| Deletion safety         | `gn_can_delete`                                    |
+| Discover the surface    | `gn_help`, `gn_tool_contract`                      |
+
+Confirm the exact surface for an installed version with `gn_tool_contract`;
+it reports advertised versus callable names and any drift.
 
 ## Resources Reference
 
-Lightweight reads (~100-500 tokens) for navigation:
+Lightweight reads (~100-500 tokens) for navigation. `mcp-doctor` may report the
+resource bridge as "not exposed"; when it is unavailable, use the tools above
+instead of assuming the resource read failed for another reason.
 
 | Resource                                       | Content                                   |
 | ---------------------------------------------- | ----------------------------------------- |

--- a/ontoindex-claude-plugin/skills/ontoindex-impact-analysis/SKILL.md
+++ b/ontoindex-claude-plugin/skills/ontoindex-impact-analysis/SKILL.md
@@ -17,32 +17,45 @@ description: "Use when the user wants to know what will break if they change som
 ## Workflow
 
 ```
-1. ontoindex_impact({target: "X", direction: "upstream"})  → What depends on this
-2. READ ontoindex://repo/{name}/processes                   → Check affected execution flows
-3. ontoindex_detect_changes()                               → Map current git changes to affected flows
-4. Assess risk and report to user
+1. gn_ensure_fresh({repo})                                       → Confirm freshness first
+2. impact({action: "symbol", repo, target: "X", direction: "upstream"})  → What depends on this
+3. gn_safe_edit_check({repo, symbol: "X"})                       → Pre-edit safety gate
+4. gn_verify_diff({repo, scope: "all"})                          → Map current changes to affected flows
+5. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner lock rules in `ontoindex-cli`.
+
+If no OntoIndex tool is callable, report the missing tool and stop the
+impact-gated edit. Reading source alone does not satisfy this gate.
 
 ## Checklist
 
 ```
-- [ ] ontoindex_impact({target, direction: "upstream"}) to find dependents
-- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] gn_ensure_fresh({repo}) and record the freshness state
+- [ ] impact({action: "symbol", target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (highest review priority)
 - [ ] Check high-confidence (>0.8) dependencies
-- [ ] READ processes to check affected execution flows
-- [ ] ontoindex_detect_changes() for pre-commit check
+- [ ] gn_verify_diff for the pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
 ## Understanding Output
 
-| Depth | Risk Level       | Meaning                  |
-| ----- | ---------------- | ------------------------ |
-| d=1   | **WILL BREAK**   | Direct callers/importers |
-| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
-| d=3   | MAY NEED TESTING | Transitive effects       |
+Depth measures dependency distance, not certainty of breakage. A direct
+dependent breaks only if the change alters behavior it relies on. Report
+dependents as review scope and confirm actual breakage by reading the call site
+or running its tests.
+
+| Depth | Review priority | Meaning                                      |
+| ----- | --------------- | -------------------------------------------- |
+| d=1   | HIGHEST         | Direct callers/importers; inspect every one   |
+| d=2   | LIKELY AFFECTED | Indirect dependencies                         |
+| d=3   | MAY NEED TESTING| Transitive effects                            |
+
+A dirty worktree lowers scope confidence: uncommitted edits are not in the
+graph. Verify those against current source or the diff.
 
 ## Risk Assessment
 
@@ -55,17 +68,18 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**ontoindex_impact** — the primary tool for symbol blast radius:
+**impact** — the primary tool for symbol blast radius:
 
 ```
-ontoindex_impact({
+impact({
+  action: "symbol",
+  repo: "<repo>",
   target: "validateUser",
   direction: "upstream",
-  minConfidence: 0.8,
-  maxDepth: 3
+  depth: 3
 })
 
-→ d=1 (WILL BREAK):
+→ d=1 (INSPECT EACH):
   - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
   - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
 
@@ -73,25 +87,26 @@ ontoindex_impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**ontoindex_detect_changes** — git-diff based impact analysis:
+**gn_verify_diff** — git-diff based impact analysis:
 
 ```
-ontoindex_detect_changes({scope: "staged"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
 → Risk: MEDIUM
 ```
 
-## Example: "What breaks if I change validateUser?"
+## Example: "What is affected if I change validateUser?"
 
 ```
-1. ontoindex_impact({target: "validateUser", direction: "upstream"})
-   → d=1: loginHandler, apiMiddleware (WILL BREAK)
-   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+1. gn_ensure_fresh({repo: "my-app"})
+   → fresh, clean worktree
 
-2. READ ontoindex://repo/my-app/processes
-   → LoginFlow and TokenRefresh touch validateUser
+2. impact({action: "symbol", repo: "my-app", target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (inspect both)
+   → d=2: authRouter, sessionManager (likely affected)
 
 3. Risk: 2 direct callers, 2 processes = MEDIUM
+   Report the blast radius and warn before editing on HIGH or CRITICAL.
 ```

--- a/ontoindex-claude-plugin/skills/ontoindex-pr-review/SKILL.md
+++ b/ontoindex-claude-plugin/skills/ontoindex-pr-review/SKILL.md
@@ -18,24 +18,29 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ```
 1. gh pr diff <number>                                    → Get the raw diff
-2. ontoindex_detect_changes({scope: "compare", base_ref: "main"})  → Map diff to affected flows
-3. For each changed symbol:
-   ontoindex_impact({target: "<symbol>", direction: "upstream"})    → Blast radius per change
-4. ontoindex_context({name: "<key symbol>"})               → Understand callers/callees
-5. READ ontoindex://repo/{name}/processes                   → Check affected execution flows
+2. gn_ensure_fresh({repo})                                → Check freshness first
+3. gn_review_diff({repo}) / gn_verify_diff({repo, scope: "all"})  → Map diff to affected flows
+4. For each changed symbol:
+   impact({action: "symbol", repo, target: "<symbol>", direction: "upstream"})  → Blast radius
+5. inspect({action: "context", repo, target: "<key symbol>"})  → Understand callers/callees
 6. Summarize findings with risk assessment
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal before reviewing.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli` before reviewing.
+
+Uncommitted or unindexed PR code is not in the graph. Verify those changes
+against the diff or current source.
 
 ## Checklist
 
 ```
 - [ ] Fetch PR diff (gh pr diff or git diff base...head)
-- [ ] ontoindex_detect_changes to map changes to affected execution flows
-- [ ] ontoindex_impact on each non-trivial changed symbol
-- [ ] Review d=1 items (WILL BREAK) — are callers updated?
-- [ ] ontoindex_context on key changed symbols to understand full picture
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] gn_verify_diff to map changes to affected execution flows
+- [ ] impact({action: "symbol"}) on each non-trivial changed symbol
+- [ ] Review d=1 items — are callers updated for the actual behavior change?
+- [ ] inspect({action: "context"}) on key changed symbols
 - [ ] Check if affected processes have test coverage
 - [ ] Assess overall risk level
 - [ ] Write review summary with findings
@@ -63,22 +68,23 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Tools
 
-**ontoindex_detect_changes** — map PR diff to affected execution flows:
+**gn_verify_diff** — map PR diff to affected execution flows (`gn_review_diff`
+and `gn_diff_impact` give review-shaped variants):
 
 ```
-ontoindex_detect_changes({scope: "compare", base_ref: "main"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 
 → Changed: 8 symbols in 4 files
 → Affected processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Risk: MEDIUM
 ```
 
-**ontoindex_impact** — blast radius per changed symbol:
+**impact** — blast radius per changed symbol:
 
 ```
-ontoindex_impact({target: "validatePayment", direction: "upstream"})
+impact({action: "symbol", repo: "<repo>", target: "validatePayment", direction: "upstream"})
 
-→ d=1 (WILL BREAK):
+→ d=1 (INSPECT EACH):
   - processCheckout (src/checkout.ts:42) [CALLS, 100%]
   - webhookHandler (src/webhooks.ts:15) [CALLS, 100%]
 
@@ -86,20 +92,20 @@ ontoindex_impact({target: "validatePayment", direction: "upstream"})
   - checkoutRouter (src/routes/checkout.ts:22) [CALLS, 95%]
 ```
 
-**ontoindex_impact with tests** — check test coverage:
+**gn_test_gap / gn_test_suggestions** — check test coverage for the change:
 
 ```
-ontoindex_impact({target: "validatePayment", direction: "upstream", includeTests: true})
+gn_test_gap({repo: "<repo>"})
 
 → Tests that cover this symbol:
   - validatePayment.test.ts [direct]
   - checkout.integration.test.ts [via processCheckout]
 ```
 
-**ontoindex_context** — understand a changed symbol's role:
+**inspect** — understand a changed symbol's role:
 
 ```
-ontoindex_context({name: "validatePayment"})
+inspect({action: "context", repo: "<repo>", target: "validatePayment"})
 
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates
@@ -112,20 +118,20 @@ ontoindex_context({name: "validatePayment"})
 1. gh pr diff 42 > /tmp/pr42.diff
    → 4 files changed: payments.ts, checkout.ts, types.ts, utils.ts
 
-2. ontoindex_detect_changes({scope: "compare", base_ref: "main"})
+2. gn_verify_diff({repo: "my-app", scope: "all"})
    → Changed symbols: validatePayment, PaymentInput, formatAmount
    → Affected processes: CheckoutFlow, RefundFlow
    → Risk: MEDIUM
 
-3. ontoindex_impact({target: "validatePayment", direction: "upstream"})
-   → d=1: processCheckout, webhookHandler (WILL BREAK)
+3. impact({action: "symbol", repo: "my-app", target: "validatePayment", direction: "upstream"})
+   → d=1: processCheckout, webhookHandler (inspect both)
    → webhookHandler is NOT in the PR diff — potential breakage!
 
-4. ontoindex_impact({target: "PaymentInput", direction: "upstream"})
+4. impact({action: "symbol", repo: "my-app", target: "PaymentInput", direction: "upstream"})
    → d=1: validatePayment (in PR), createPayment (NOT in PR)
    → createPayment uses the old PaymentInput shape — breaking change!
 
-5. ontoindex_context({name: "formatAmount"})
+5. inspect({action: "context", repo: "my-app", target: "formatAmount"})
    → Called by 12 functions — but change is backwards-compatible (added optional param)
 
 6. Review summary:

--- a/ontoindex-claude-plugin/skills/ontoindex-refactoring/SKILL.md
+++ b/ontoindex-claude-plugin/skills/ontoindex-refactoring/SKILL.md
@@ -16,106 +16,107 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 ## Workflow
 
 ```
-1. ontoindex_impact({target: "X", direction: "upstream"})  → Map all dependents
-2. ontoindex_query({query: "X"})                            → Find execution flows involving X
-3. ontoindex_context({name: "X"})                           → See all incoming/outgoing refs
-4. Plan update order: interfaces → implementations → callers → tests
+1. gn_ensure_fresh({repo})                                          → Check freshness first
+2. impact({action: "symbol", repo, target: "X", direction: "upstream"})  → Map all dependents
+3. inspect({action: "context", repo, target: "X"})                  → See all incoming/outgoing refs
+4. gn_safe_edit_check({repo, symbol: "X"})                          → Pre-edit safety gate
+5. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+Never rename symbols with find-and-replace. If the rename tooling is not
+callable, report it and stop rather than editing blindly.
 
 ## Checklists
 
 ### Rename Symbol
 
 ```
-- [ ] ontoindex_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] refactor({action: "rename", repo, target: "oldName", ..., dry_run: true}) — preview all edits
 - [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
-- [ ] If satisfied: ontoindex_rename({..., dry_run: false}) — apply edits
-- [ ] ontoindex_detect_changes() — verify only expected files changed
+- [ ] If satisfied, re-run with dry_run: false — apply edits
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
 ```
-- [ ] ontoindex_context({name: target}) — see all incoming/outgoing refs
-- [ ] ontoindex_impact({target, direction: "upstream"}) — find all external callers
-- [ ] Define new module interface
-- [ ] Extract code, update imports
-- [ ] ontoindex_detect_changes() — verify affected scope
+- [ ] inspect({action: "context", target}) — see all incoming/outgoing refs
+- [ ] impact({action: "symbol", target, direction: "upstream"}) — find external callers
+- [ ] gn_propose_location({repo}) — check the intended destination
+- [ ] Define new module interface, extract code, update imports
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
 ```
-- [ ] ontoindex_context({name: target}) — understand all callees
+- [ ] inspect({action: "context", target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] ontoindex_impact({target, direction: "upstream"}) — map callers to update
-- [ ] Create new functions/services
-- [ ] Update callers
-- [ ] ontoindex_detect_changes() — verify affected scope
+- [ ] impact({action: "symbol", target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services, update callers
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**ontoindex_rename** — automated multi-file rename:
+**refactor** — automated multi-file rename (`gn_safe_refactor` is the
+compatibility equivalent):
 
 ```
-ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+refactor({action: "rename", repo: "<repo>", target: "validateUser", dry_run: true})
 → 12 edits across 8 files
 → 10 graph edits (high confidence), 2 ast_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**ontoindex_impact** — map all dependents first:
+**impact** — map all dependents first:
 
 ```
-ontoindex_impact({target: "validateUser", direction: "upstream"})
+impact({action: "symbol", repo: "<repo>", target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**ontoindex_detect_changes** — verify your changes after refactoring:
+**gn_verify_diff** — verify your changes after refactoring:
 
 ```
-ontoindex_detect_changes({scope: "all"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**ontoindex_cypher** — custom reference queries:
-
-```cypher
-MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
-RETURN caller.name, caller.filePath ORDER BY caller.filePath
-```
+**gn_graph_walk** — custom reference traversal when the facades are not
+specific enough.
 
 ## Risk Rules
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use ontoindex_rename for automated updates |
-| Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | ontoindex_query to find them               |
-| External/public API | Version and deprecate properly            |
+| Many callers (>5)   | Use `refactor({action: "rename"})` for updates |
+| Cross-area refs     | Use `gn_verify_diff` after to verify scope    |
+| String/dynamic refs | `search({action: "semantic"})` to find them   |
+| External/public API | Version and deprecate properly                |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
 ```
-1. ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+1. refactor({action: "rename", repo: "my-app", target: "validateUser", dry_run: true})
    → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
 2. Review ast_search edits (config.json: dynamic reference!)
 
-3. ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. Re-run the same call with dry_run: false
    → Applied 12 edits across 8 files
 
-4. ontoindex_detect_changes({scope: "all"})
+4. gn_verify_diff({repo: "my-app", scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/ontoindex-cursor-integration/skills/ontoindex-debugging/SKILL.md
+++ b/ontoindex-cursor-integration/skills/ontoindex-debugging/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: ontoindex-debugging
-description: Trace bugs through call chains using knowledge graph
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
 ---
 
 # Debugging with OntoIndex
 
 ## When to Use
+
 - "Why is this function failing?"
 - "Trace where this error comes from"
 - "Who calls this method?"
@@ -15,71 +16,74 @@ description: Trace bugs through call chains using knowledge graph
 ## Workflow
 
 ```
-1. ontoindex_query({query: "<error or symptom>"})            → Find related execution flows
-2. ontoindex_context({name: "<suspect>"})                    → See callers/callees/processes
-3. READ ontoindex://repo/{name}/process/{name}                → Trace execution flow
-4. ontoindex_cypher({query: "MATCH path..."})                 → Custom traces if needed
+1. gn_ensure_fresh({repo})                                   → Check freshness first
+2. search({action: "semantic", repo, query: "<symptom>"})    → Find related execution flows
+3. inspect({action: "context", repo, target: "<suspect>"})   → See callers/callees/processes
+4. gn_diagnose({repo}) / gn_error_topology({repo})           → Failure-path evidence
+5. Read source files to confirm the root cause
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+A dirty worktree is not represented in the graph. Confirm any suspect code
+against current source before concluding a root cause. If OntoIndex is required
+but not callable, report the missing tool instead of substituting grep.
 
 ## Checklist
 
 ```
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] ontoindex_query for error text or related code
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] search({action: "semantic"}) for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] ontoindex_context to see callers and callees
-- [ ] Trace execution flow via process resource if applicable
-- [ ] ontoindex_cypher for custom call chain traces if needed
+- [ ] inspect({action: "context"}) to see callers and callees
 - [ ] Read source files to confirm root cause
 ```
 
 ## Debugging Patterns
 
-| Symptom | OntoIndex Approach |
-|---------|-------------------|
-| Error message | `ontoindex_query` for error text → `context` on throw sites |
-| Wrong return value | `context` on the function → trace callees for data flow |
-| Intermittent failure | `context` → look for external calls, async deps |
-| Performance issue | `context` → find symbols with many callers (hot paths) |
-| Recent regression | `detect_changes` to see what your changes affect |
+| Symptom              | OntoIndex Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `search` for error text → `inspect` on throw sites          |
+| Wrong return value   | `inspect` on the function → trace callees for data flow     |
+| Intermittent failure | `inspect` → look for external calls, async deps             |
+| Performance issue    | `inspect` → find symbols with many callers (hot paths)      |
+| Recent regression    | `gn_verify_diff` to see what your changes affect            |
 
 ## Tools
 
-**ontoindex_query** — find code related to error:
+**search** — find code related to error:
+
 ```
-ontoindex_query({query: "payment validation error"})
+search({action: "semantic", repo: "<repo>", query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**ontoindex_context** — full context for a suspect:
+**inspect** — full context for a suspect:
+
 ```
-ontoindex_context({name: "validatePayment"})
+inspect({action: "context", repo: "<repo>", target: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**ontoindex_cypher** — custom call chain traces:
-```cypher
-MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
-RETURN [n IN nodes(path) | n.name] AS chain
-```
+**gn_graph_walk / gn_trace_boundary** — custom call chain and boundary traces
+when `search` and `inspect` do not isolate the path.
 
 ## Example: "Payment endpoint returns 500 intermittently"
 
 ```
-1. ontoindex_query({query: "payment error handling"})
+1. search({action: "semantic", repo: "my-app", query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. ontoindex_context({name: "validatePayment"})
+2. inspect({action: "context", repo: "my-app", target: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
-3. READ ontoindex://repo/my-app/process/CheckoutFlow
-   → Step 3: validatePayment → calls fetchRates (external)
+3. Read the fetchRates source to confirm the timeout behavior
 
 4. Root cause: fetchRates calls external API without proper timeout
 ```

--- a/ontoindex-cursor-integration/skills/ontoindex-exploring/SKILL.md
+++ b/ontoindex-cursor-integration/skills/ontoindex-exploring/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: ontoindex-exploring
-description: Navigate unfamiliar code using OntoIndex knowledge graph
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
 ---
 
 # Exploring Codebases with OntoIndex
 
 ## When to Use
+
 - "How does authentication work?"
 - "What's the project structure?"
 - "Show me the main components"
@@ -15,47 +16,54 @@ description: Navigate unfamiliar code using OntoIndex knowledge graph
 ## Workflow
 
 ```
-1. READ ontoindex://repos                          → Discover indexed repos
-2. READ ontoindex://repo/{name}/context             → Codebase overview, check staleness
-3. ontoindex_query({query: "<what you want to understand>"})  → Find related execution flows
-4. ontoindex_context({name: "<symbol>"})            → Deep dive on specific symbol
-5. READ ontoindex://repo/{name}/process/{name}      → Trace full execution flow
+1. gn_ensure_fresh({repo})                                   → Check freshness first
+2. search({action: "semantic", repo, query: "<concept>"})    → Find related execution flows
+3. inspect({action: "context", repo, target: "<symbol>"})    → Deep dive on a symbol
+4. gn_explain_module({repo, module})                         → Module-level overview
+5. Read source files for implementation details
 ```
 
-> If step 2 says "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+Prefer graph search over grep for discovery. If OntoIndex is required but not
+callable, say so explicitly rather than presenting grep results as
+graph-backed evidence.
 
 ## Checklist
 
 ```
-- [ ] READ ontoindex://repo/{name}/context
-- [ ] ontoindex_query for the concept you want to understand
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] search({action: "semantic"}) for the concept
 - [ ] Review returned processes (execution flows)
-- [ ] ontoindex_context on key symbols for callers/callees
-- [ ] READ process resource for full execution traces
+- [ ] inspect({action: "context"}) on key symbols for callers/callees
 - [ ] Read source files for implementation details
+- [ ] Verify uncommitted changes against current source, not the graph
 ```
 
 ## Resources
 
-| Resource | What you get |
-|----------|-------------|
-| `ontoindex://repo/{name}/context` | Stats, staleness warning (~150 tokens) |
-| `ontoindex://repo/{name}/clusters` | All functional areas with cohesion scores (~300 tokens) |
-| `ontoindex://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens) |
-| `ontoindex://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens) |
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `ontoindex://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `ontoindex://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `ontoindex://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `ontoindex://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
 
 ## Tools
 
-**ontoindex_query** — find execution flows related to a concept:
+**search** — find execution flows related to a concept:
+
 ```
-ontoindex_query({query: "payment processing"})
+search({action: "semantic", repo: "<repo>", query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**ontoindex_context** — 360-degree view of a symbol:
+**inspect** — 360-degree view of a symbol:
+
 ```
-ontoindex_context({name: "validateUser"})
+inspect({action: "context", repo: "<repo>", target: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -64,11 +72,11 @@ ontoindex_context({name: "validateUser"})
 ## Example: "How does payment processing work?"
 
 ```
-1. READ ontoindex://repo/my-app/context       → 918 symbols, 45 processes
-2. ontoindex_query({query: "payment processing"})
+1. gn_ensure_fresh({repo: "my-app"})          → fresh
+2. search({action: "semantic", repo: "my-app", query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. ontoindex_context({name: "processPayment"})
+3. inspect({action: "context", repo: "my-app", target: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/ontoindex-cursor-integration/skills/ontoindex-impact-analysis/SKILL.md
+++ b/ontoindex-cursor-integration/skills/ontoindex-impact-analysis/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: ontoindex-impact-analysis
-description: Analyze blast radius before making code changes
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
 ---
 
 # Impact Analysis with OntoIndex
 
 ## When to Use
+
 - "Is it safe to change this function?"
 - "What will break if I modify X?"
 - "Show me the blast radius"
@@ -16,54 +17,69 @@ description: Analyze blast radius before making code changes
 ## Workflow
 
 ```
-1. ontoindex_impact({target: "X", direction: "upstream"})  → What depends on this
-2. READ ontoindex://repo/{name}/processes                   → Check affected execution flows
-3. ontoindex_detect_changes()                               → Map current git changes to affected flows
-4. Assess risk and report to user
+1. gn_ensure_fresh({repo})                                       → Confirm freshness first
+2. impact({action: "symbol", repo, target: "X", direction: "upstream"})  → What depends on this
+3. gn_safe_edit_check({repo, symbol: "X"})                       → Pre-edit safety gate
+4. gn_verify_diff({repo, scope: "all"})                          → Map current changes to affected flows
+5. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner lock rules in `ontoindex-cli`.
+
+If no OntoIndex tool is callable, report the missing tool and stop the
+impact-gated edit. Reading source alone does not satisfy this gate.
 
 ## Checklist
 
 ```
-- [ ] ontoindex_impact({target, direction: "upstream"}) to find dependents
-- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] gn_ensure_fresh({repo}) and record the freshness state
+- [ ] impact({action: "symbol", target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (highest review priority)
 - [ ] Check high-confidence (>0.8) dependencies
-- [ ] READ processes to check affected execution flows
-- [ ] ontoindex_detect_changes() for pre-commit check
+- [ ] gn_verify_diff for the pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
 ## Understanding Output
 
-| Depth | Risk Level | Meaning |
-|-------|-----------|---------|
-| d=1 | **WILL BREAK** | Direct callers/importers |
-| d=2 | LIKELY AFFECTED | Indirect dependencies |
-| d=3 | MAY NEED TESTING | Transitive effects |
+Depth measures dependency distance, not certainty of breakage. A direct
+dependent breaks only if the change alters behavior it relies on. Report
+dependents as review scope and confirm actual breakage by reading the call site
+or running its tests.
+
+| Depth | Review priority | Meaning                                      |
+| ----- | --------------- | -------------------------------------------- |
+| d=1   | HIGHEST         | Direct callers/importers; inspect every one   |
+| d=2   | LIKELY AFFECTED | Indirect dependencies                         |
+| d=3   | MAY NEED TESTING| Transitive effects                            |
+
+A dirty worktree lowers scope confidence: uncommitted edits are not in the
+graph. Verify those against current source or the diff.
 
 ## Risk Assessment
 
-| Affected | Risk |
-|----------|------|
-| <5 symbols, few processes | LOW |
-| 5-15 symbols, 2-5 processes | MEDIUM |
-| >15 symbols or many processes | HIGH |
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
 | Critical path (auth, payments) | CRITICAL |
 
 ## Tools
 
-**ontoindex_impact** — the primary tool for symbol blast radius:
+**impact** — the primary tool for symbol blast radius:
+
 ```
-ontoindex_impact({
+impact({
+  action: "symbol",
+  repo: "<repo>",
   target: "validateUser",
   direction: "upstream",
-  minConfidence: 0.8,
-  maxDepth: 3
+  depth: 3
 })
 
-→ d=1 (WILL BREAK):
+→ d=1 (INSPECT EACH):
   - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
   - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
 
@@ -71,24 +87,26 @@ ontoindex_impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**ontoindex_detect_changes** — git-diff based impact analysis:
+**gn_verify_diff** — git-diff based impact analysis:
+
 ```
-ontoindex_detect_changes({scope: "staged"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
 → Risk: MEDIUM
 ```
 
-## Example: "What breaks if I change validateUser?"
+## Example: "What is affected if I change validateUser?"
 
 ```
-1. ontoindex_impact({target: "validateUser", direction: "upstream"})
-   → d=1: loginHandler, apiMiddleware (WILL BREAK)
-   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+1. gn_ensure_fresh({repo: "my-app"})
+   → fresh, clean worktree
 
-2. READ ontoindex://repo/my-app/processes
-   → LoginFlow and TokenRefresh touch validateUser
+2. impact({action: "symbol", repo: "my-app", target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (inspect both)
+   → d=2: authRouter, sessionManager (likely affected)
 
 3. Risk: 2 direct callers, 2 processes = MEDIUM
+   Report the blast radius and warn before editing on HIGH or CRITICAL.
 ```

--- a/ontoindex-cursor-integration/skills/ontoindex-pr-review/SKILL.md
+++ b/ontoindex-cursor-integration/skills/ontoindex-pr-review/SKILL.md
@@ -18,24 +18,29 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ```
 1. gh pr diff <number>                                    → Get the raw diff
-2. ontoindex_detect_changes({scope: "compare", base_ref: "main"})  → Map diff to affected flows
-3. For each changed symbol:
-   ontoindex_impact({target: "<symbol>", direction: "upstream"})    → Blast radius per change
-4. ontoindex_context({name: "<key symbol>"})               → Understand callers/callees
-5. READ ontoindex://repo/{name}/processes                   → Check affected execution flows
+2. gn_ensure_fresh({repo})                                → Check freshness first
+3. gn_review_diff({repo}) / gn_verify_diff({repo, scope: "all"})  → Map diff to affected flows
+4. For each changed symbol:
+   impact({action: "symbol", repo, target: "<symbol>", direction: "upstream"})  → Blast radius
+5. inspect({action: "context", repo, target: "<key symbol>"})  → Understand callers/callees
 6. Summarize findings with risk assessment
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal before reviewing.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli` before reviewing.
+
+Uncommitted or unindexed PR code is not in the graph. Verify those changes
+against the diff or current source.
 
 ## Checklist
 
 ```
 - [ ] Fetch PR diff (gh pr diff or git diff base...head)
-- [ ] ontoindex_detect_changes to map changes to affected execution flows
-- [ ] ontoindex_impact on each non-trivial changed symbol
-- [ ] Review d=1 items (WILL BREAK) — are callers updated?
-- [ ] ontoindex_context on key changed symbols to understand full picture
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] gn_verify_diff to map changes to affected execution flows
+- [ ] impact({action: "symbol"}) on each non-trivial changed symbol
+- [ ] Review d=1 items — are callers updated for the actual behavior change?
+- [ ] inspect({action: "context"}) on key changed symbols
 - [ ] Check if affected processes have test coverage
 - [ ] Assess overall risk level
 - [ ] Write review summary with findings
@@ -63,22 +68,23 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Tools
 
-**ontoindex_detect_changes** — map PR diff to affected execution flows:
+**gn_verify_diff** — map PR diff to affected execution flows (`gn_review_diff`
+and `gn_diff_impact` give review-shaped variants):
 
 ```
-ontoindex_detect_changes({scope: "compare", base_ref: "main"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 
 → Changed: 8 symbols in 4 files
 → Affected processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Risk: MEDIUM
 ```
 
-**ontoindex_impact** — blast radius per changed symbol:
+**impact** — blast radius per changed symbol:
 
 ```
-ontoindex_impact({target: "validatePayment", direction: "upstream"})
+impact({action: "symbol", repo: "<repo>", target: "validatePayment", direction: "upstream"})
 
-→ d=1 (WILL BREAK):
+→ d=1 (INSPECT EACH):
   - processCheckout (src/checkout.ts:42) [CALLS, 100%]
   - webhookHandler (src/webhooks.ts:15) [CALLS, 100%]
 
@@ -86,20 +92,20 @@ ontoindex_impact({target: "validatePayment", direction: "upstream"})
   - checkoutRouter (src/routes/checkout.ts:22) [CALLS, 95%]
 ```
 
-**ontoindex_impact with tests** — check test coverage:
+**gn_test_gap / gn_test_suggestions** — check test coverage for the change:
 
 ```
-ontoindex_impact({target: "validatePayment", direction: "upstream", includeTests: true})
+gn_test_gap({repo: "<repo>"})
 
 → Tests that cover this symbol:
   - validatePayment.test.ts [direct]
   - checkout.integration.test.ts [via processCheckout]
 ```
 
-**ontoindex_context** — understand a changed symbol's role:
+**inspect** — understand a changed symbol's role:
 
 ```
-ontoindex_context({name: "validatePayment"})
+inspect({action: "context", repo: "<repo>", target: "validatePayment"})
 
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates
@@ -112,20 +118,20 @@ ontoindex_context({name: "validatePayment"})
 1. gh pr diff 42 > /tmp/pr42.diff
    → 4 files changed: payments.ts, checkout.ts, types.ts, utils.ts
 
-2. ontoindex_detect_changes({scope: "compare", base_ref: "main"})
+2. gn_verify_diff({repo: "my-app", scope: "all"})
    → Changed symbols: validatePayment, PaymentInput, formatAmount
    → Affected processes: CheckoutFlow, RefundFlow
    → Risk: MEDIUM
 
-3. ontoindex_impact({target: "validatePayment", direction: "upstream"})
-   → d=1: processCheckout, webhookHandler (WILL BREAK)
+3. impact({action: "symbol", repo: "my-app", target: "validatePayment", direction: "upstream"})
+   → d=1: processCheckout, webhookHandler (inspect both)
    → webhookHandler is NOT in the PR diff — potential breakage!
 
-4. ontoindex_impact({target: "PaymentInput", direction: "upstream"})
+4. impact({action: "symbol", repo: "my-app", target: "PaymentInput", direction: "upstream"})
    → d=1: validatePayment (in PR), createPayment (NOT in PR)
    → createPayment uses the old PaymentInput shape — breaking change!
 
-5. ontoindex_context({name: "formatAmount"})
+5. inspect({action: "context", repo: "my-app", target: "formatAmount"})
    → Called by 12 functions — but change is backwards-compatible (added optional param)
 
 6. Review summary:

--- a/ontoindex-cursor-integration/skills/ontoindex-refactoring/SKILL.md
+++ b/ontoindex-cursor-integration/skills/ontoindex-refactoring/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: ontoindex-refactoring
-description: Plan safe refactors using blast radius and dependency mapping
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
 ---
 
 # Refactoring with OntoIndex
 
 ## When to Use
+
 - "Rename this function safely"
 - "Extract this into a module"
 - "Split this service"
@@ -15,99 +16,107 @@ description: Plan safe refactors using blast radius and dependency mapping
 ## Workflow
 
 ```
-1. ontoindex_impact({target: "X", direction: "upstream"})  → Map all dependents
-2. ontoindex_query({query: "X"})                            → Find execution flows involving X
-3. ontoindex_context({name: "X"})                           → See all incoming/outgoing refs
-4. Plan update order: interfaces → implementations → callers → tests
+1. gn_ensure_fresh({repo})                                          → Check freshness first
+2. impact({action: "symbol", repo, target: "X", direction: "upstream"})  → Map all dependents
+3. inspect({action: "context", repo, target: "X"})                  → See all incoming/outgoing refs
+4. gn_safe_edit_check({repo, symbol: "X"})                          → Pre-edit safety gate
+5. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+Never rename symbols with find-and-replace. If the rename tooling is not
+callable, report it and stop rather than editing blindly.
 
 ## Checklists
 
 ### Rename Symbol
+
 ```
-- [ ] ontoindex_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] refactor({action: "rename", repo, target: "oldName", ..., dry_run: true}) — preview all edits
 - [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
-- [ ] If satisfied: ontoindex_rename({..., dry_run: false}) — apply edits
-- [ ] ontoindex_detect_changes() — verify only expected files changed
+- [ ] If satisfied, re-run with dry_run: false — apply edits
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
+
 ```
-- [ ] ontoindex_context({name: target}) — see all incoming/outgoing refs
-- [ ] ontoindex_impact({target, direction: "upstream"}) — find all external callers
-- [ ] Define new module interface
-- [ ] Extract code, update imports
-- [ ] ontoindex_detect_changes() — verify affected scope
+- [ ] inspect({action: "context", target}) — see all incoming/outgoing refs
+- [ ] impact({action: "symbol", target, direction: "upstream"}) — find external callers
+- [ ] gn_propose_location({repo}) — check the intended destination
+- [ ] Define new module interface, extract code, update imports
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
+
 ```
-- [ ] ontoindex_context({name: target}) — understand all callees
+- [ ] inspect({action: "context", target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] ontoindex_impact({target, direction: "upstream"}) — map callers to update
-- [ ] Create new functions/services
-- [ ] Update callers
-- [ ] ontoindex_detect_changes() — verify affected scope
+- [ ] impact({action: "symbol", target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services, update callers
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**ontoindex_rename** — automated multi-file rename:
+**refactor** — automated multi-file rename (`gn_safe_refactor` is the
+compatibility equivalent):
+
 ```
-ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+refactor({action: "rename", repo: "<repo>", target: "validateUser", dry_run: true})
 → 12 edits across 8 files
 → 10 graph edits (high confidence), 2 ast_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**ontoindex_impact** — map all dependents first:
+**impact** — map all dependents first:
+
 ```
-ontoindex_impact({target: "validateUser", direction: "upstream"})
+impact({action: "symbol", repo: "<repo>", target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**ontoindex_detect_changes** — verify your changes after refactoring:
+**gn_verify_diff** — verify your changes after refactoring:
+
 ```
-ontoindex_detect_changes({scope: "all"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**ontoindex_cypher** — custom reference queries:
-```cypher
-MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
-RETURN caller.name, caller.filePath ORDER BY caller.filePath
-```
+**gn_graph_walk** — custom reference traversal when the facades are not
+specific enough.
 
 ## Risk Rules
 
-| Risk Factor | Mitigation |
-|-------------|------------|
-| Many callers (>5) | Use ontoindex_rename for automated updates |
-| Cross-area refs | Use detect_changes after to verify scope |
-| String/dynamic refs | ontoindex_query to find them |
-| External/public API | Version and deprecate properly |
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use `refactor({action: "rename"})` for updates |
+| Cross-area refs     | Use `gn_verify_diff` after to verify scope    |
+| String/dynamic refs | `search({action: "semantic"})` to find them   |
+| External/public API | Version and deprecate properly                |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
 ```
-1. ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+1. refactor({action: "rename", repo: "my-app", target: "validateUser", dry_run: true})
    → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
 2. Review ast_search edits (config.json: dynamic reference!)
 
-3. ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. Re-run the same call with dry_run: false
    → Applied 12 edits across 8 files
 
-4. ontoindex_detect_changes({scope: "all"})
+4. gn_verify_diff({repo: "my-app", scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/ontoindex/skills/ontoindex-cli.md
+++ b/ontoindex/skills/ontoindex-cli.md
@@ -5,7 +5,26 @@ description: "Use when the user needs to run OntoIndex CLI commands like analyze
 
 # OntoIndex CLI Commands
 
-All commands work via `npx` — no global install required.
+Use the installed `ontoindex` binary when it is on PATH; otherwise `npx
+ontoindex` works without a global install. Verified against OntoIndex 2.2.0.
+
+## MCP Availability
+
+When OntoIndex is required but no OntoIndex tool is callable in the session,
+treat it as a tooling failure and repair it before graph-backed work:
+
+```bash
+ontoindex mcp-doctor --repo <repo>   # verdict, freshness, and exact repair command
+ontoindex setup                      # register MCP for supported clients
+```
+
+`mcp-doctor` reports whether an MCP process is running, whether the resource
+bridge is exposed, and which repair command to run. After `setup` writes the
+client configuration, the client must be restarted to load the server.
+
+The `ontoindex` facade dispatcher is advertised but not callable in the default
+`public-full` startup profile. Use the `search`, `inspect`, `impact`, and
+`refactor` facades or the `gn_*` tools.
 
 ## Commands
 
@@ -75,8 +94,39 @@ Lists all repositories registered in `~/.ontoindex/registry.json`. The MCP `list
 1. **Read `ontoindex://repo/{name}/context`** to verify the index loaded
 2. Use the other OntoIndex skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
 
+## Stale-Index Recovery
+
+When an OntoIndex query reports a stale index or cannot resolve a symbol that
+exists in current source:
+
+1. Preserve the blocked query and its arguments.
+2. Check freshness with `gn_ensure_fresh`. If the index is current, return to
+   the query instead of starting analysis.
+3. Before refresh, inspect `.ontoindex/analyze.lock`. Never start a second
+   analysis while its recorded PID is alive. Clear the lock only after proving
+   that PID is dead.
+4. Submit one background refresh with `gn_ensure_fresh(autoAnalyze=true)` and
+   observe it with `gn_analyze_job`. For an Axel CLI refresh already running by
+   PID and log, route monitoring through `axel-background-job-watch`.
+5. Accept refresh only after the job exits successfully and
+   `gn_ensure_fresh` reports the expected freshness state. Dirty-worktree
+   freshness is valid only for claims checked against current source or diff.
+6. Retry the blocked graph query once with its original arguments. Report the
+   refresh evidence and keep unresolved results provisional.
+
+Do not request embeddings unless the blocked operation requires semantic or
+vector retrieval. Graph impact and traversal need only the normal index.
+
 ## Troubleshooting
 
 - **"Not inside a git repository"**: Run from a directory inside a git repo
 - **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
 - **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding
+
+## Routine Tool Ownership
+
+This skill owns routine-tool operation 39, `ONTOINDEX_FRESH_GATE`, in
+`~/.ontocode/skills/ontocode-routine-tools/references/tool-catalog.md`. The gate
+must verify commit/index/job/publication identity and fail closed before graph
+queries when freshness cannot be proven. Return the coordinator's shared
+envelope.

--- a/ontoindex/skills/ontoindex-debugging.md
+++ b/ontoindex/skills/ontoindex-debugging.md
@@ -16,23 +16,28 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 ## Workflow
 
 ```
-1. ontoindex_query({query: "<error or symptom>"})            → Find related execution flows
-2. ontoindex_context({name: "<suspect>"})                    → See callers/callees/processes
-3. READ ontoindex://repo/{name}/process/{name}                → Trace execution flow
-4. ontoindex_cypher({query: "MATCH path..."})                 → Custom traces if needed
+1. gn_ensure_fresh({repo})                                   → Check freshness first
+2. search({action: "semantic", repo, query: "<symptom>"})    → Find related execution flows
+3. inspect({action: "context", repo, target: "<suspect>"})   → See callers/callees/processes
+4. gn_diagnose({repo}) / gn_error_topology({repo})           → Failure-path evidence
+5. Read source files to confirm the root cause
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+A dirty worktree is not represented in the graph. Confirm any suspect code
+against current source before concluding a root cause. If OntoIndex is required
+but not callable, report the missing tool instead of substituting grep.
 
 ## Checklist
 
 ```
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] ontoindex_query for error text or related code
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] search({action: "semantic"}) for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] ontoindex_context to see callers and callees
-- [ ] Trace execution flow via process resource if applicable
-- [ ] ontoindex_cypher for custom call chain traces if needed
+- [ ] inspect({action: "context"}) to see callers and callees
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,50 +45,45 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | OntoIndex Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `ontoindex_query` for error text → `context` on throw sites |
-| Wrong return value   | `context` on the function → trace callees for data flow    |
-| Intermittent failure | `context` → look for external calls, async deps            |
-| Performance issue    | `context` → find symbols with many callers (hot paths)     |
-| Recent regression    | `detect_changes` to see what your changes affect           |
+| Error message        | `search` for error text → `inspect` on throw sites          |
+| Wrong return value   | `inspect` on the function → trace callees for data flow     |
+| Intermittent failure | `inspect` → look for external calls, async deps             |
+| Performance issue    | `inspect` → find symbols with many callers (hot paths)      |
+| Recent regression    | `gn_verify_diff` to see what your changes affect            |
 
 ## Tools
 
-**ontoindex_query** — find code related to error:
+**search** — find code related to error:
 
 ```
-ontoindex_query({query: "payment validation error"})
+search({action: "semantic", repo: "<repo>", query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**ontoindex_context** — full context for a suspect:
+**inspect** — full context for a suspect:
 
 ```
-ontoindex_context({name: "validatePayment"})
+inspect({action: "context", repo: "<repo>", target: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**ontoindex_cypher** — custom call chain traces:
-
-```cypher
-MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
-RETURN [n IN nodes(path) | n.name] AS chain
-```
+**gn_graph_walk / gn_trace_boundary** — custom call chain and boundary traces
+when `search` and `inspect` do not isolate the path.
 
 ## Example: "Payment endpoint returns 500 intermittently"
 
 ```
-1. ontoindex_query({query: "payment error handling"})
+1. search({action: "semantic", repo: "my-app", query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. ontoindex_context({name: "validatePayment"})
+2. inspect({action: "context", repo: "my-app", target: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
-3. READ ontoindex://repo/my-app/process/CheckoutFlow
-   → Step 3: validatePayment → calls fetchRates (external)
+3. Read the fetchRates source to confirm the timeout behavior
 
 4. Root cause: fetchRates calls external API without proper timeout
 ```

--- a/ontoindex/skills/ontoindex-exploring.md
+++ b/ontoindex/skills/ontoindex-exploring.md
@@ -16,24 +16,29 @@ description: "Use when the user asks how code works, wants to understand archite
 ## Workflow
 
 ```
-1. READ ontoindex://repos                          → Discover indexed repos
-2. READ ontoindex://repo/{name}/context             → Codebase overview, check staleness
-3. ontoindex_query({query: "<what you want to understand>"})  → Find related execution flows
-4. ontoindex_context({name: "<symbol>"})            → Deep dive on specific symbol
-5. READ ontoindex://repo/{name}/process/{name}      → Trace full execution flow
+1. gn_ensure_fresh({repo})                                   → Check freshness first
+2. search({action: "semantic", repo, query: "<concept>"})    → Find related execution flows
+3. inspect({action: "context", repo, target: "<symbol>"})    → Deep dive on a symbol
+4. gn_explain_module({repo, module})                         → Module-level overview
+5. Read source files for implementation details
 ```
 
-> If step 2 says "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+Prefer graph search over grep for discovery. If OntoIndex is required but not
+callable, say so explicitly rather than presenting grep results as
+graph-backed evidence.
 
 ## Checklist
 
 ```
-- [ ] READ ontoindex://repo/{name}/context
-- [ ] ontoindex_query for the concept you want to understand
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] search({action: "semantic"}) for the concept
 - [ ] Review returned processes (execution flows)
-- [ ] ontoindex_context on key symbols for callers/callees
-- [ ] READ process resource for full execution traces
+- [ ] inspect({action: "context"}) on key symbols for callers/callees
 - [ ] Read source files for implementation details
+- [ ] Verify uncommitted changes against current source, not the graph
 ```
 
 ## Resources
@@ -47,18 +52,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**ontoindex_query** — find execution flows related to a concept:
+**search** — find execution flows related to a concept:
 
 ```
-ontoindex_query({query: "payment processing"})
+search({action: "semantic", repo: "<repo>", query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**ontoindex_context** — 360-degree view of a symbol:
+**inspect** — 360-degree view of a symbol:
 
 ```
-ontoindex_context({name: "validateUser"})
+inspect({action: "context", repo: "<repo>", target: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -67,11 +72,11 @@ ontoindex_context({name: "validateUser"})
 ## Example: "How does payment processing work?"
 
 ```
-1. READ ontoindex://repo/my-app/context       → 918 symbols, 45 processes
-2. ontoindex_query({query: "payment processing"})
+1. gn_ensure_fresh({repo: "my-app"})          → fresh
+2. search({action: "semantic", repo: "my-app", query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. ontoindex_context({name: "processPayment"})
+3. inspect({action: "context", repo: "my-app", target: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/ontoindex/skills/ontoindex-guide.md
+++ b/ontoindex/skills/ontoindex-guide.md
@@ -7,15 +7,50 @@ description: "Use when the user asks about OntoIndex itself — available tools,
 
 Quick reference for all OntoIndex MCP tools, resources, and the knowledge graph schema.
 
+Verified against OntoIndex 2.2.0 on 2026-09-05 by calling the running MCP
+server (`gn_tool_contract`).
+
 ## Always Start Here
 
 For any task involving code understanding, debugging, impact analysis, or refactoring:
 
-1. **Read `ontoindex://repo/{name}/context`** — codebase overview + check index freshness
+1. **Check freshness** with `gn_ensure_fresh({repo})` before any graph-backed claim.
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx ontoindex analyze` in the terminal first.
+If OntoIndex is required but no OntoIndex tool is callable, stop and report the
+missing tool. Do not silently fall back to grep-only inspection and present the
+result as graph-backed evidence. Repair with `ontoindex mcp-doctor` and
+`ontoindex setup`, then confirm the tools are callable.
+
+> If freshness reports stale, refresh with `ontoindex analyze`. See
+> `ontoindex-cli` for the single-owner lock and job rules.
+
+## Tool Naming
+
+Two callable surfaces exist. Both are served by the same MCP server.
+
+- Facade tools take an `action`: `search`, `inspect`, `impact`, `refactor`,
+  `audit`, `docs`, `discover`, `manage`.
+- Compatibility tools are the 54 `gn_*` tools, such as `gn_explore`,
+  `gn_ensure_fresh`, `gn_verify_diff`, and `gn_safe_edit_check`.
+
+The `ontoindex` dispatcher tool is advertised by the registry but is **not**
+callable in the default `public-full` startup profile; calling it returns
+`Unknown tool method: ontoindex`. Use a facade or `gn_*` tool instead.
+
+Verified callable examples:
+
+```
+search({action: "semantic", repo: "<repo>", query: "concept"})
+inspect({action: "context", repo: "<repo>", target: "symbolName"})
+impact({action: "symbol", repo: "<repo>", target: "symbolName", direction: "upstream"})
+gn_ensure_fresh({repo: "<repo>"})
+```
+
+Older `ontoindex_query`, `ontoindex_context`, `ontoindex_impact`,
+`ontoindex_rename`, and `ontoindex_detect_changes` names are **not** callable in
+2.2.0. Use the facade or `gn_*` equivalents below.
 
 ## Skills
 
@@ -30,19 +65,26 @@ For any task involving code understanding, debugging, impact analysis, or refact
 
 ## Tools Reference
 
-| Tool             | What it gives you                                                        |
-| ---------------- | ------------------------------------------------------------------------ |
-| `query`          | Process-grouped code intelligence — execution flows related to a concept |
-| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
-| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
-| `detect_changes` | Git-diff impact — what do your current changes affect                    |
-| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
-| `cypher`         | Raw graph queries (read `ontoindex://repo/{name}/schema` first)           |
-| `list_repos`     | Discover indexed repos                                                   |
+| Intent                  | Callable tool                                     |
+| ----------------------- | ------------------------------------------------- |
+| Find execution flows    | `search({action: "semantic"})` or `gn_explore`     |
+| Symbol callers/callees  | `inspect({action: "context"})` or `gn_find_related`|
+| Blast radius            | `impact({action: "symbol"})`                       |
+| Pre-edit safety check   | `gn_safe_edit_check`                               |
+| Diff/commit verification| `gn_verify_diff`, `gn_diff_impact`                 |
+| Coordinated rename      | `refactor({action: "rename"})`, `gn_safe_refactor` |
+| Index freshness         | `gn_ensure_fresh`, `gn_analyze_job`                |
+| Deletion safety         | `gn_can_delete`                                    |
+| Discover the surface    | `gn_help`, `gn_tool_contract`                      |
+
+Confirm the exact surface for an installed version with `gn_tool_contract`;
+it reports advertised versus callable names and any drift.
 
 ## Resources Reference
 
-Lightweight reads (~100-500 tokens) for navigation:
+Lightweight reads (~100-500 tokens) for navigation. `mcp-doctor` may report the
+resource bridge as "not exposed"; when it is unavailable, use the tools above
+instead of assuming the resource read failed for another reason.
 
 | Resource                                       | Content                                   |
 | ---------------------------------------------- | ----------------------------------------- |

--- a/ontoindex/skills/ontoindex-impact-analysis.md
+++ b/ontoindex/skills/ontoindex-impact-analysis.md
@@ -17,32 +17,45 @@ description: "Use when the user wants to know what will break if they change som
 ## Workflow
 
 ```
-1. ontoindex_impact({target: "X", direction: "upstream"})  → What depends on this
-2. READ ontoindex://repo/{name}/processes                   → Check affected execution flows
-3. ontoindex_detect_changes()                               → Map current git changes to affected flows
-4. Assess risk and report to user
+1. gn_ensure_fresh({repo})                                       → Confirm freshness first
+2. impact({action: "symbol", repo, target: "X", direction: "upstream"})  → What depends on this
+3. gn_safe_edit_check({repo, symbol: "X"})                       → Pre-edit safety gate
+4. gn_verify_diff({repo, scope: "all"})                          → Map current changes to affected flows
+5. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner lock rules in `ontoindex-cli`.
+
+If no OntoIndex tool is callable, report the missing tool and stop the
+impact-gated edit. Reading source alone does not satisfy this gate.
 
 ## Checklist
 
 ```
-- [ ] ontoindex_impact({target, direction: "upstream"}) to find dependents
-- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] gn_ensure_fresh({repo}) and record the freshness state
+- [ ] impact({action: "symbol", target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (highest review priority)
 - [ ] Check high-confidence (>0.8) dependencies
-- [ ] READ processes to check affected execution flows
-- [ ] ontoindex_detect_changes() for pre-commit check
+- [ ] gn_verify_diff for the pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
 ## Understanding Output
 
-| Depth | Risk Level       | Meaning                  |
-| ----- | ---------------- | ------------------------ |
-| d=1   | **WILL BREAK**   | Direct callers/importers |
-| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
-| d=3   | MAY NEED TESTING | Transitive effects       |
+Depth measures dependency distance, not certainty of breakage. A direct
+dependent breaks only if the change alters behavior it relies on. Report
+dependents as review scope and confirm actual breakage by reading the call site
+or running its tests.
+
+| Depth | Review priority | Meaning                                      |
+| ----- | --------------- | -------------------------------------------- |
+| d=1   | HIGHEST         | Direct callers/importers; inspect every one   |
+| d=2   | LIKELY AFFECTED | Indirect dependencies                         |
+| d=3   | MAY NEED TESTING| Transitive effects                            |
+
+A dirty worktree lowers scope confidence: uncommitted edits are not in the
+graph. Verify those against current source or the diff.
 
 ## Risk Assessment
 
@@ -55,17 +68,18 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**ontoindex_impact** — the primary tool for symbol blast radius:
+**impact** — the primary tool for symbol blast radius:
 
 ```
-ontoindex_impact({
+impact({
+  action: "symbol",
+  repo: "<repo>",
   target: "validateUser",
   direction: "upstream",
-  minConfidence: 0.8,
-  maxDepth: 3
+  depth: 3
 })
 
-→ d=1 (WILL BREAK):
+→ d=1 (INSPECT EACH):
   - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
   - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
 
@@ -73,25 +87,26 @@ ontoindex_impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**ontoindex_detect_changes** — git-diff based impact analysis:
+**gn_verify_diff** — git-diff based impact analysis:
 
 ```
-ontoindex_detect_changes({scope: "staged"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
 → Risk: MEDIUM
 ```
 
-## Example: "What breaks if I change validateUser?"
+## Example: "What is affected if I change validateUser?"
 
 ```
-1. ontoindex_impact({target: "validateUser", direction: "upstream"})
-   → d=1: loginHandler, apiMiddleware (WILL BREAK)
-   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+1. gn_ensure_fresh({repo: "my-app"})
+   → fresh, clean worktree
 
-2. READ ontoindex://repo/my-app/processes
-   → LoginFlow and TokenRefresh touch validateUser
+2. impact({action: "symbol", repo: "my-app", target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (inspect both)
+   → d=2: authRouter, sessionManager (likely affected)
 
 3. Risk: 2 direct callers, 2 processes = MEDIUM
+   Report the blast radius and warn before editing on HIGH or CRITICAL.
 ```

--- a/ontoindex/skills/ontoindex-pr-review.md
+++ b/ontoindex/skills/ontoindex-pr-review.md
@@ -18,24 +18,29 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ```
 1. gh pr diff <number>                                    → Get the raw diff
-2. ontoindex_detect_changes({scope: "compare", base_ref: "main"})  → Map diff to affected flows
-3. For each changed symbol:
-   ontoindex_impact({target: "<symbol>", direction: "upstream"})    → Blast radius per change
-4. ontoindex_context({name: "<key symbol>"})               → Understand callers/callees
-5. READ ontoindex://repo/{name}/processes                   → Check affected execution flows
+2. gn_ensure_fresh({repo})                                → Check freshness first
+3. gn_review_diff({repo}) / gn_verify_diff({repo, scope: "all"})  → Map diff to affected flows
+4. For each changed symbol:
+   impact({action: "symbol", repo, target: "<symbol>", direction: "upstream"})  → Blast radius
+5. inspect({action: "context", repo, target: "<key symbol>"})  → Understand callers/callees
 6. Summarize findings with risk assessment
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal before reviewing.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli` before reviewing.
+
+Uncommitted or unindexed PR code is not in the graph. Verify those changes
+against the diff or current source.
 
 ## Checklist
 
 ```
 - [ ] Fetch PR diff (gh pr diff or git diff base...head)
-- [ ] ontoindex_detect_changes to map changes to affected execution flows
-- [ ] ontoindex_impact on each non-trivial changed symbol
-- [ ] Review d=1 items (WILL BREAK) — are callers updated?
-- [ ] ontoindex_context on key changed symbols to understand full picture
+- [ ] gn_ensure_fresh({repo}) and record freshness
+- [ ] gn_verify_diff to map changes to affected execution flows
+- [ ] impact({action: "symbol"}) on each non-trivial changed symbol
+- [ ] Review d=1 items — are callers updated for the actual behavior change?
+- [ ] inspect({action: "context"}) on key changed symbols
 - [ ] Check if affected processes have test coverage
 - [ ] Assess overall risk level
 - [ ] Write review summary with findings
@@ -63,22 +68,23 @@ description: "Use when the user wants to review a pull request, understand what 
 
 ## Tools
 
-**ontoindex_detect_changes** — map PR diff to affected execution flows:
+**gn_verify_diff** — map PR diff to affected execution flows (`gn_review_diff`
+and `gn_diff_impact` give review-shaped variants):
 
 ```
-ontoindex_detect_changes({scope: "compare", base_ref: "main"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 
 → Changed: 8 symbols in 4 files
 → Affected processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Risk: MEDIUM
 ```
 
-**ontoindex_impact** — blast radius per changed symbol:
+**impact** — blast radius per changed symbol:
 
 ```
-ontoindex_impact({target: "validatePayment", direction: "upstream"})
+impact({action: "symbol", repo: "<repo>", target: "validatePayment", direction: "upstream"})
 
-→ d=1 (WILL BREAK):
+→ d=1 (INSPECT EACH):
   - processCheckout (src/checkout.ts:42) [CALLS, 100%]
   - webhookHandler (src/webhooks.ts:15) [CALLS, 100%]
 
@@ -86,20 +92,20 @@ ontoindex_impact({target: "validatePayment", direction: "upstream"})
   - checkoutRouter (src/routes/checkout.ts:22) [CALLS, 95%]
 ```
 
-**ontoindex_impact with tests** — check test coverage:
+**gn_test_gap / gn_test_suggestions** — check test coverage for the change:
 
 ```
-ontoindex_impact({target: "validatePayment", direction: "upstream", includeTests: true})
+gn_test_gap({repo: "<repo>"})
 
 → Tests that cover this symbol:
   - validatePayment.test.ts [direct]
   - checkout.integration.test.ts [via processCheckout]
 ```
 
-**ontoindex_context** — understand a changed symbol's role:
+**inspect** — understand a changed symbol's role:
 
 ```
-ontoindex_context({name: "validatePayment"})
+inspect({action: "context", repo: "<repo>", target: "validatePayment"})
 
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates
@@ -112,20 +118,20 @@ ontoindex_context({name: "validatePayment"})
 1. gh pr diff 42 > /tmp/pr42.diff
    → 4 files changed: payments.ts, checkout.ts, types.ts, utils.ts
 
-2. ontoindex_detect_changes({scope: "compare", base_ref: "main"})
+2. gn_verify_diff({repo: "my-app", scope: "all"})
    → Changed symbols: validatePayment, PaymentInput, formatAmount
    → Affected processes: CheckoutFlow, RefundFlow
    → Risk: MEDIUM
 
-3. ontoindex_impact({target: "validatePayment", direction: "upstream"})
-   → d=1: processCheckout, webhookHandler (WILL BREAK)
+3. impact({action: "symbol", repo: "my-app", target: "validatePayment", direction: "upstream"})
+   → d=1: processCheckout, webhookHandler (inspect both)
    → webhookHandler is NOT in the PR diff — potential breakage!
 
-4. ontoindex_impact({target: "PaymentInput", direction: "upstream"})
+4. impact({action: "symbol", repo: "my-app", target: "PaymentInput", direction: "upstream"})
    → d=1: validatePayment (in PR), createPayment (NOT in PR)
    → createPayment uses the old PaymentInput shape — breaking change!
 
-5. ontoindex_context({name: "formatAmount"})
+5. inspect({action: "context", repo: "my-app", target: "formatAmount"})
    → Called by 12 functions — but change is backwards-compatible (added optional param)
 
 6. Review summary:

--- a/ontoindex/skills/ontoindex-refactoring.md
+++ b/ontoindex/skills/ontoindex-refactoring.md
@@ -16,106 +16,107 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 ## Workflow
 
 ```
-1. ontoindex_impact({target: "X", direction: "upstream"})  → Map all dependents
-2. ontoindex_query({query: "X"})                            → Find execution flows involving X
-3. ontoindex_context({name: "X"})                           → See all incoming/outgoing refs
-4. Plan update order: interfaces → implementations → callers → tests
+1. gn_ensure_fresh({repo})                                          → Check freshness first
+2. impact({action: "symbol", repo, target: "X", direction: "upstream"})  → Map all dependents
+3. inspect({action: "context", repo, target: "X"})                  → See all incoming/outgoing refs
+4. gn_safe_edit_check({repo, symbol: "X"})                          → Pre-edit safety gate
+5. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx ontoindex analyze` in terminal.
+> If freshness reports stale, refresh with `ontoindex analyze` under the
+> single-owner rules in `ontoindex-cli`.
+
+Never rename symbols with find-and-replace. If the rename tooling is not
+callable, report it and stop rather than editing blindly.
 
 ## Checklists
 
 ### Rename Symbol
 
 ```
-- [ ] ontoindex_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] refactor({action: "rename", repo, target: "oldName", ..., dry_run: true}) — preview all edits
 - [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
-- [ ] If satisfied: ontoindex_rename({..., dry_run: false}) — apply edits
-- [ ] ontoindex_detect_changes() — verify only expected files changed
+- [ ] If satisfied, re-run with dry_run: false — apply edits
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
 ```
-- [ ] ontoindex_context({name: target}) — see all incoming/outgoing refs
-- [ ] ontoindex_impact({target, direction: "upstream"}) — find all external callers
-- [ ] Define new module interface
-- [ ] Extract code, update imports
-- [ ] ontoindex_detect_changes() — verify affected scope
+- [ ] inspect({action: "context", target}) — see all incoming/outgoing refs
+- [ ] impact({action: "symbol", target, direction: "upstream"}) — find external callers
+- [ ] gn_propose_location({repo}) — check the intended destination
+- [ ] Define new module interface, extract code, update imports
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
 ```
-- [ ] ontoindex_context({name: target}) — understand all callees
+- [ ] inspect({action: "context", target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] ontoindex_impact({target, direction: "upstream"}) — map callers to update
-- [ ] Create new functions/services
-- [ ] Update callers
-- [ ] ontoindex_detect_changes() — verify affected scope
+- [ ] impact({action: "symbol", target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services, update callers
+- [ ] gn_verify_diff({repo, scope: "all"}) — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**ontoindex_rename** — automated multi-file rename:
+**refactor** — automated multi-file rename (`gn_safe_refactor` is the
+compatibility equivalent):
 
 ```
-ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+refactor({action: "rename", repo: "<repo>", target: "validateUser", dry_run: true})
 → 12 edits across 8 files
 → 10 graph edits (high confidence), 2 ast_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**ontoindex_impact** — map all dependents first:
+**impact** — map all dependents first:
 
 ```
-ontoindex_impact({target: "validateUser", direction: "upstream"})
+impact({action: "symbol", repo: "<repo>", target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**ontoindex_detect_changes** — verify your changes after refactoring:
+**gn_verify_diff** — verify your changes after refactoring:
 
 ```
-ontoindex_detect_changes({scope: "all"})
+gn_verify_diff({repo: "<repo>", scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**ontoindex_cypher** — custom reference queries:
-
-```cypher
-MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
-RETURN caller.name, caller.filePath ORDER BY caller.filePath
-```
+**gn_graph_walk** — custom reference traversal when the facades are not
+specific enough.
 
 ## Risk Rules
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use ontoindex_rename for automated updates |
-| Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | ontoindex_query to find them               |
-| External/public API | Version and deprecate properly            |
+| Many callers (>5)   | Use `refactor({action: "rename"})` for updates |
+| Cross-area refs     | Use `gn_verify_diff` after to verify scope    |
+| String/dynamic refs | `search({action: "semantic"})` to find them   |
+| External/public API | Version and deprecate properly                |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
 ```
-1. ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+1. refactor({action: "rename", repo: "my-app", target: "validateUser", dry_run: true})
    → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
 2. Review ast_search edits (config.json: dynamic reference!)
 
-3. ontoindex_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. Re-run the same call with dry_run: false
    → Applied 12 edits across 8 files
 
-4. ontoindex_detect_changes({scope: "all"})
+4. gn_verify_diff({repo: "my-app", scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/ontoindex/src/cli/setup.ts
+++ b/ontoindex/src/cli/setup.ts
@@ -869,6 +869,28 @@ async function installCodexSkills(result: SetupResult): Promise<void> {
   }
 }
 
+/**
+ * Install global Ontocode skills to ~/.ontocode/skills/
+ *
+ * Ontocode already receives MCP configuration, agent guidance, and hooks during
+ * setup. Without this step its skill copies are never refreshed, so agents keep
+ * reading stale tool names after an upgrade.
+ */
+async function installOntocodeSkills(result: SetupResult): Promise<void> {
+  const ontocodeDir = path.join(os.homedir(), '.ontocode');
+  if (!(await dirExists(ontocodeDir))) return;
+
+  const skillsDir = path.join(ontocodeDir, 'skills');
+  try {
+    const installed = await installSkillsTo(skillsDir);
+    if (installed.length > 0) {
+      result.configured.push(`Ontocode skills (${installed.length} skills → ~/.ontocode/skills/)`);
+    }
+  } catch (err: unknown) {
+    result.errors.push(`Ontocode skills: ${caughtMessage(err)}`);
+  }
+}
+
 // ─── Main command ──────────────────────────────────────────────────
 
 export const setupCommand = async () => {
@@ -931,6 +953,7 @@ export const setupCommand = async () => {
   await installCodexSkills(result);
   await installCodexHooks(result);
 
+  await installOntocodeSkills(result);
   await installOntocodeHooks(result);
 
   // Print results

--- a/ontoindex/test/integration/setup-skills.test.ts
+++ b/ontoindex/test/integration/setup-skills.test.ts
@@ -132,4 +132,34 @@ describe('setupCommand skills integration', () => {
 
     expect(sectionMatches).toHaveLength(1);
   });
+
+  it('installs skills into ~/.ontocode/skills when Ontocode is present', async () => {
+    await fs.mkdir(path.join(tempHome, '.ontocode'), { recursive: true });
+
+    await setupCommand();
+
+    const ontocodeSkill = await fs.readFile(
+      path.join(tempHome, '.ontocode', 'skills', 'ontoindex-cli', 'SKILL.md'),
+      'utf-8',
+    );
+    expect(ontocodeSkill.startsWith('---')).toBe(true);
+    expect(ontocodeSkill).toContain('OntoIndex CLI Commands');
+  });
+
+  it('does not create ~/.ontocode/skills when Ontocode is absent', async () => {
+    const isolatedHome = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-setup-no-ontocode-'));
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    process.env.HOME = isolatedHome;
+    process.env.USERPROFILE = isolatedHome;
+
+    try {
+      await setupCommand();
+      await expect(fs.access(path.join(isolatedHome, '.ontocode', 'skills'))).rejects.toThrow();
+    } finally {
+      process.env.HOME = previousHome;
+      process.env.USERPROFILE = previousUserProfile;
+      await fs.rm(isolatedHome, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/install-ontoindex-latest.ps1
+++ b/scripts/install-ontoindex-latest.ps1
@@ -566,12 +566,34 @@ try {
   throw
 }
 
+$skipSetup = $env:ONTOINDEX_SKIP_SETUP -eq "1"
+if ($skipSetup) {
+  Write-Host "Skipping skill and MCP setup: ONTOINDEX_SKIP_SETUP=1"
+} else {
+  Write-Host "Running 'ontoindex setup' to install skills and configure MCP clients"
+  try {
+    & $binPath setup
+    if ($LASTEXITCODE -ne 0) {
+      throw "ontoindex setup exited with code $LASTEXITCODE"
+    }
+  } catch {
+    Write-Warning "'ontoindex setup' failed; the install itself is complete."
+    Write-Warning "Rerun 'ontoindex setup' manually to install skills and configure MCP clients."
+  }
+}
+
 Write-Host "Note: this installer uses npm to resolve third-party runtime packages."
 Write-Host "A non-fatal npm warning about deprecated transitive packages can appear while upstream packages catch up."
 Write-Host "For air-gapped installs, use a separately prepared npm cache or internal registry mirror."
 Write-Host ""
-Write-Host "Next step: run 'ontoindex setup' after installation to configure MCP clients and agent guidance."
+if ($skipSetup) {
+  Write-Host "Next step: run 'ontoindex setup' to configure MCP clients, skills, and agent guidance."
+} else {
+  Write-Host "Skills and MCP client configuration were installed by 'ontoindex setup'."
+  Write-Host "Restart your editor or agent client so it loads the OntoIndex MCP server."
+}
 Write-Host "The setup command is idempotent and will not duplicate existing OntoIndex settings."
+Write-Host "Set ONTOINDEX_SKIP_SETUP=1 to install without running setup."
 
 if (($env:Path -split ';') -notcontains $NpmPrefix -and (Test-Path (Join-Path $NpmPrefix "ontoindex.cmd"))) {
   Write-Host ""

--- a/scripts/install-ontoindex-latest.sh
+++ b/scripts/install-ontoindex-latest.sh
@@ -380,13 +380,40 @@ fi
 log "Installed OntoIndex:"
 validate_install "${install_prefix}" "${bin_path}"
 
+run_setup() {
+  local bin="${1}"
+
+  if [ "${ONTOINDEX_SKIP_SETUP:-0}" = "1" ]; then
+    log "Skipping skill and MCP setup: ONTOINDEX_SKIP_SETUP=1"
+    echo "Run 'ontoindex setup' later to configure MCP clients, skills, and agent guidance."
+    return 0
+  fi
+
+  log "Running 'ontoindex setup' to install skills and configure MCP clients"
+  if "${bin}" setup; then
+    return 0
+  fi
+
+  echo "warning: 'ontoindex setup' failed; the install itself is complete." >&2
+  echo "warning: rerun 'ontoindex setup' manually to install skills and configure MCP clients." >&2
+  return 0
+}
+
+run_setup "${bin_path}"
+
 log "Install complete."
 echo "Note: this installer uses npm to resolve third-party runtime packages."
 echo "A non-fatal npm warning about deprecated transitive packages can appear while upstream packages catch up."
 echo "For air-gapped installs, use a separately prepared npm cache or internal registry mirror."
 echo ""
-echo "Next step: run 'ontoindex setup' after installation to configure MCP clients and agent guidance."
+if [ "${ONTOINDEX_SKIP_SETUP:-0}" = "1" ]; then
+  echo "Next step: run 'ontoindex setup' to configure MCP clients, skills, and agent guidance."
+else
+  echo "Skills and MCP client configuration were installed by 'ontoindex setup'."
+  echo "Restart your editor or agent client so it loads the OntoIndex MCP server."
+fi
 echo "The setup command is idempotent and will not duplicate existing OntoIndex settings."
+echo "Set ONTOINDEX_SKIP_SETUP=1 to install without running setup."
 if [ "${install_prefix}" = "${USER_PREFIX}" ] && ! printf '%s' ":${PATH}:" | grep -Fq ":${USER_PREFIX}/bin:"; then
   echo "Add ${USER_PREFIX}/bin to PATH to use ontoindex in new shells."
 fi


### PR DESCRIPTION
## Problem

The bundled OntoIndex skills documented tool names that do not exist in the 2.x MCP surface: `ontoindex_query`, `ontoindex_context`, `ontoindex_impact`, `ontoindex_rename`, and `ontoindex_detect_changes`.

An agent following the skills calls a tool that always fails, falls back to grep, and then reports the result as graph-backed evidence. The failure is silent, so the agent looks like it used the knowledge graph when it did not.

Two smaller issues came from the same review:

- Impact and PR-review guidance labeled every direct dependent `WILL BREAK`. Dependency distance is review priority, not proof of breakage, so agents reported unverified regressions.
- `ontoindex setup` configured MCP, agent guidance, and hooks for Ontocode but never installed its skills. Its copies under `~/.ontocode/skills/` stayed stale across upgrades, which is how the wrong tool names survived.

## Changes

Rewrote the seven skills against the surface reported by `gn_tool_contract`: the `search`, `inspect`, `impact`, and `refactor` facades plus the `gn_*` tools. Every `gn_*` name used is verified against the registry. The canonical `ontoindex/skills/` sources and the Claude-plugin and Cursor copies are now in sync.

Added `installOntocodeSkills` to `setup.ts`, matching the existing Claude, Cursor, Codex, and OpenCode installers. It is a no-op when `~/.ontocode` is absent.

Both installers now run `ontoindex setup` after a validated install, so skills and MCP configuration land without a second command. A setup failure is a warning and never fails the install; `ONTOINDEX_SKIP_SETUP=1` opts out.

Also documented that the `ontoindex` facade dispatcher is advertised by the registry but is not callable in the default `public-full` profile, and added explicit missing-tool handling so an agent reports an unavailable tool instead of substituting grep.

## Verification

- `npx tsc --noEmit` passes.
- `npx eslint` passes on both changed TypeScript files.
- `prettier --check` passes on all changed Markdown and TypeScript.
- `test/integration/setup-skills.test.ts`: 5 of 6 pass, including two new Ontocode cases covering install and the absent-directory no-op. The one failure (`dist/cli/index.js`) reproduces identically on unmodified `master` because a source checkout has no build.
- `test/unit/setup.test.ts`, `setup-codex.test.ts`, `skill-gen.test.ts`: 43 passed / 8 failed, identical counts on unmodified `master`. All pre-existing and build-related.
- `bash -n` passes on the shell installer. The setup call, the `ONTOINDEX_SKIP_SETUP=1` path, and the failure path were exercised against a stub binary under `set -euo pipefail` to confirm a failing setup does not abort the install.

Tool names were verified against a running MCP server for OntoIndex 2.2.0 (54 `gn_*` tools, 8 facade tools, no drift), not inferred from the existing docs.
